### PR TITLE
Card UI issue for Mozilla Firefox browser

### DIFF
--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -146,6 +146,8 @@ const Card = ({ card, placeholder, folded }: cardProps) => {
                 '& > div': {
                     transition: 'transform 0.6s',
                     transformStyle: 'preserve-3d',
+                    WebkitTransformStyle: 'preserve-3d',
+                    MozTransformStyle: 'preserve-3d',
                 },
             }}
             width={'100%'}
@@ -159,6 +161,8 @@ const Card = ({ card, placeholder, folded }: cardProps) => {
                 sx={{
                     transition: 'transform 0.6s',
                     transformStyle: 'preserve-3d',
+                    WebkitTransformStyle: 'preserve-3d',
+                    MozTransformStyle: 'preserve-3d',
                     transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
                 }}
             >
@@ -168,6 +172,11 @@ const Card = ({ card, placeholder, folded }: cardProps) => {
                     height="100%"
                     sx={{
                         backfaceVisibility: 'hidden',
+                        WebkitBackfaceVisibility: 'hidden',
+                        MozBackfaceVisibility: 'hidden',
+                        transformStyle: 'preserve-3d',
+                        WebkitTransformStyle: 'preserve-3d',
+                        MozTransformStyle: 'preserve-3d',
                     }}
                 >
                     <CardImage


### PR DESCRIPTION
- fixes visual issues with card flipping in some browsers by adding necessary vendor prefixes
- added `WebkitTransformStyle` and `MozTransformStyle` to ensure consistent 3D transform rendering

closes #104 