### PR TITLE
Improve TakenSeatButton UI

### DIFF
--- a/app/components/TakenSeatButton.tsx
+++ b/app/components/TakenSeatButton.tsx
@@ -13,15 +13,15 @@ import { AppContext } from '../contexts/AppStoreProvider';
 import CardComponent from './Card';
 
 const pulseWhiteGlow = keyframes`
-  0% { box-shadow: 0 0 8px 3px rgba(255, 255, 255, 0.8); }
-  50% { box-shadow: 0 0 16px 8px rgba(255, 255, 255, 0.8); }
-  100% { box-shadow: 0 0 8px 3px rgba(255, 255, 255, 0.8); }
+  0% { box-shadow: 0 0 6px 5px rgba(255, 255, 255, 0.6); }
+  50% { box-shadow: 0 0 9px 6px rgba(255, 255, 255, 0.6); }
+  100% { box-shadow: 0 0 6px 5px rgba(255, 255, 255, 0.6); }
 `;
 
 const pulseGoldGlow = keyframes`
-  0% { box-shadow: 0 0 8px 2px rgba(255, 215, 0, 0.7); }
-  50% { box-shadow: 0 0 16px 8px rgba(255, 215, 0, 0.7); }
-  100% { box-shadow: 0 0 8px 2px rgba(255, 215, 0, 0.7); }
+  0% { box-shadow: 0 0 6px 5px rgba(255, 215, 0, 0.6); }
+  50% { box-shadow: 0 0 9px 6px rgba(255, 215, 0, 0.6); }
+  100% { box-shadow: 0 0 6px 5px rgba(255, 215, 0, 0.6); }
 `;
 
 const TakenSeatButton = ({
@@ -110,15 +110,9 @@ const TakenSeatButton = ({
     const chipPosition = chipPositions[player?.seatID || 4] || defaultPosition;
 
     const glowAnimation = isCurrentTurn
-        ? `${pulseWhiteGlow} 2s ease-in-out infinite`
+        ? `${pulseWhiteGlow} 2s ease-in-out 0.2s infinite`
         : isWinner
-          ? `${pulseGoldGlow} 2s ease-in-out infinite`
-          : 'none';
-
-    const boxShadow = isCurrentTurn
-        ? '0 0 25px 10px rgba(255, 255, 255, 1)'
-        : isWinner
-          ? '0 0 10px 3px rgba(255, 215, 0, 0.7)'
+          ? `${pulseGoldGlow} 2s ease-in-out 0.5s infinite`
           : 'none';
 
     if (!appState.game) {
@@ -200,7 +194,7 @@ const TakenSeatButton = ({
             </Flex>
             <Flex
                 direction={'column'}
-                bg={'gray.50'}
+                bg={isCurrentTurn || isWinner ? 'white' : 'gray.50'}
                 borderRadius={12}
                 width={'110%'}
                 paddingX={4}
@@ -210,23 +204,32 @@ const TakenSeatButton = ({
                 justifyContent={'center'}
                 alignItems={'center'}
                 alignSelf={'flex-end'}
-                boxShadow={boxShadow}
                 animation={glowAnimation}
-                transition="all 0.5s ease-in-out"
+                transition={'all 0.5s ease-in-out'}
             >
                 <HStack spacing={2}>
                     <Text
                         variant={'seatText'}
                         fontWeight={'bold'}
-                        color={'gray.300'}
+                        color={
+                            isCurrentTurn || isWinner ? 'gray.700' : 'gray.300'
+                        }
                     >
                         {player.username}
                     </Text>
-                    <Text variant={'seatText'} color={'gray.300'}>
+                    <Text
+                        variant={'seatText'}
+                        color={
+                            isCurrentTurn || isWinner ? 'gray.700' : 'gray.300'
+                        }
+                    >
                         {shortEthAddress}
                     </Text>
                 </HStack>
-                <Text color={'gray.300'} variant={'seatText'}>
+                <Text
+                    color={isCurrentTurn || isWinner ? 'gray.700' : 'gray.300'}
+                    variant={'seatText'}
+                >
                     {player.stack}
                 </Text>
             </Flex>

--- a/app/components/TakenSeatButton.tsx
+++ b/app/components/TakenSeatButton.tsx
@@ -7,11 +7,32 @@ import {
     PositionProps,
     HStack,
 } from '@chakra-ui/react';
+import { keyframes } from '@emotion/react';
 import { Card, Player } from '../interfaces';
 import { AppContext } from '../contexts/AppStoreProvider';
 import CardComponent from './Card';
 
-const TakenSeatButton = ({ player }: { player: Player }) => {
+const pulseWhiteGlow = keyframes`
+  0% { box-shadow: 0 0 8px 3px rgba(255, 255, 255, 0.8); }
+  50% { box-shadow: 0 0 16px 8px rgba(255, 255, 255, 0.8); }
+  100% { box-shadow: 0 0 8px 3px rgba(255, 255, 255, 0.8); }
+`;
+
+const pulseGoldGlow = keyframes`
+  0% { box-shadow: 0 0 8px 2px rgba(255, 215, 0, 0.7); }
+  50% { box-shadow: 0 0 16px 8px rgba(255, 215, 0, 0.7); }
+  100% { box-shadow: 0 0 8px 2px rgba(255, 215, 0, 0.7); }
+`;
+
+const TakenSeatButton = ({
+    player,
+    isCurrentTurn,
+    isWinner,
+}: {
+    player: Player;
+    isCurrentTurn: boolean;
+    isWinner: boolean;
+}) => {
     const { appState } = useContext(AppContext);
     const address = player?.address;
     const shortEthAddress = address
@@ -87,6 +108,18 @@ const TakenSeatButton = ({ player }: { player: Player }) => {
 
     const defaultPosition = { top: '100%', flexDirection: 'row' };
     const chipPosition = chipPositions[player?.seatID || 4] || defaultPosition;
+
+    const glowAnimation = isCurrentTurn
+        ? `${pulseWhiteGlow} 2s ease-in-out infinite`
+        : isWinner
+          ? `${pulseGoldGlow} 2s ease-in-out infinite`
+          : 'none';
+
+    const boxShadow = isCurrentTurn
+        ? '0 0 25px 10px rgba(255, 255, 255, 1)'
+        : isWinner
+          ? '0 0 10px 3px rgba(255, 215, 0, 0.7)'
+          : 'none';
 
     if (!appState.game) {
         return null;
@@ -177,6 +210,9 @@ const TakenSeatButton = ({ player }: { player: Player }) => {
                 justifyContent={'center'}
                 alignItems={'center'}
                 alignSelf={'flex-end'}
+                boxShadow={boxShadow}
+                animation={glowAnimation}
+                transition="all 0.5s ease-in-out"
             >
                 <HStack spacing={2}>
                     <Text


### PR DESCRIPTION
**Summary**
- Added glow effects to highlight players:
  - White glow when it's the player's turn
  -  Gold glow for the round winner

**Changes**
- In `Table.tsx`
  - Added `winningPlayer` state
  - Added `isPlayerTurn` and `isPlayerWinner` helper functions
  - Passed `isCurrentTurn` and `isWinner` to `TakenSeatButton`
- In `TakenSeatButton.tsx`
  - Created white and gold glow animations
  - Applied animations based on player state

Large Screen: 
https://www.loom.com/share/fb271ecda320400c965ce518596edddd?sid=7e5a2b23-d0e9-48e1-a9ae-04509d204fbc

Smaller Screens: 
https://www.loom.com/share/5612d5a8ec824d7a919dae783702277e?sid=873dd873-2127-4332-b85d-175f7bc2471b

closes #125