### PR TITLE
Table Owner

### DIFF
--- a/app/contexts/WebSocketProvider.tsx
+++ b/app/contexts/WebSocketProvider.tsx
@@ -349,7 +349,9 @@ export function SocketProvider(props: SocketProviderProps) {
                         );
                         // If seat request was denied (message check), reset the flag
                         if (
-                            eventData.message === 'Seat request denied.' &&
+                            (eventData.message === 'Seat request denied.' ||
+                                eventData.message ===
+                                    'A player is already requesting for this seat.') &&
                             appStateRef.current.isSeatRequested
                         ) {
                             dispatch({


### PR DESCRIPTION
Updated seat request denial logic to handle an additional message:
- Now resets the seat request flag if the message is either "Seat request denied." or "A player is already requesting for this seat."

Backend: https://github.com/Stacked-Labs/poker-server/pull/48

Closes #160 