### PR TITLE
prevent landscape in all pages

### DIFF
--- a/app/components/LandscapeScreen.tsx
+++ b/app/components/LandscapeScreen.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Flex, Text, useBreakpointValue } from '@chakra-ui/react';
+import React, { useEffect, useState } from 'react';
+
+const LandscapeScreen = () => {
+    const isMobile = useBreakpointValue({ base: true, lg: false }) ?? true;
+    const [orientation, setOrientation] = useState('');
+
+    useEffect(() => {
+        function updateOrientation() {
+            setOrientation(screen.orientation.type);
+        }
+
+        updateOrientation();
+        window.addEventListener('orientationchange', updateOrientation);
+        return () => {
+            window.removeEventListener('orientationchange', updateOrientation);
+        };
+    }, []);
+
+    return (
+        orientation.includes('landscape') &&
+        isMobile &&
+        window.screen.width > window.screen.height && (
+            <Flex
+                justify="center"
+                align="center"
+                w="100vw"
+                h="100vh"
+                bg={'charcoal.800'}
+                px={4}
+                position={'fixed'}
+                zIndex={999999}
+            >
+                <Text
+                    color="white    "
+                    size="xl"
+                    fontWeight="bold"
+                    align={'center'}
+                >
+                    Please rotate your device to play the game.
+                </Text>
+            </Flex>
+        )
+    );
+};
+
+export default LandscapeScreen;

--- a/app/game/[id]/layout.tsx
+++ b/app/game/[id]/layout.tsx
@@ -37,6 +37,20 @@ const GameLayout: React.FC = ({
         }
     }, [appState.game?.players]);
 
+    const [orientation, setOrientation] = useState('');
+
+    useEffect(() => {
+        function updateOrientation() {
+            setOrientation(screen.orientation.type);
+        }
+
+        updateOrientation();
+        window.addEventListener('orientationchange', updateOrientation);
+        return () => {
+            window.removeEventListener('orientationchange', updateOrientation);
+        };
+    }, [screen.orientation.type]);
+
     if (loading) {
         return (
             <Flex
@@ -64,22 +78,46 @@ const GameLayout: React.FC = ({
     }
 
     return (
-        <Flex
-            direction="column"
-            w="100vw"
-            h="var(--full-vh)"
-            zIndex="auto"
-            transformOrigin="center center"
-            bg={'gray.200'}
-        >
-            <Navbar />
-            {children}
-            <Footer />
+        <>
+            {orientation.includes('landscape') && (
+                <Flex
+                    justify="center"
+                    align="center"
+                    w="100vw"
+                    h="100vh"
+                    backgroundColor="gray"
+                    px={4}
+                    position={'fixed'}
+                    zIndex={999999}
+                >
+                    <Text
+                        color="white    "
+                        size="xl"
+                        fontWeight="bold"
+                        align={'center'}
+                    >
+                        Please rotate your device to portrait mode to play the
+                        game.
+                    </Text>
+                </Flex>
+            )}
+            <Flex
+                direction="column"
+                w="100vw"
+                h="var(--full-vh)"
+                zIndex="auto"
+                transformOrigin="center center"
+                bg={'gray.200'}
+            >
+                <Navbar />
+                {children}
+                <Footer />
 
-            <Modal isOpen={isOpen} onClose={onClose} isCentered size={'xs'}>
-                <LobbyBanner onClose={onClose} />
-            </Modal>
-        </Flex>
+                <Modal isOpen={isOpen} onClose={onClose} isCentered size={'xs'}>
+                    <LobbyBanner onClose={onClose} />
+                </Modal>
+            </Flex>
+        </>
     );
 };
 

--- a/app/game/[id]/layout.tsx
+++ b/app/game/[id]/layout.tsx
@@ -13,6 +13,7 @@ import {
 import Footer from '@/app/components/Footer';
 import { AppContext } from '@/app/contexts/AppStoreProvider';
 import LobbyBanner from '@/app/components/LobbyBanner';
+import LandscapeScreen from '@/app/components/LandscapeScreen';
 
 const GameLayout: React.FC = ({
     children,
@@ -36,20 +37,6 @@ const GameLayout: React.FC = ({
             onClose();
         }
     }, [appState.game?.players]);
-
-    const [orientation, setOrientation] = useState('');
-
-    useEffect(() => {
-        function updateOrientation() {
-            setOrientation(screen.orientation.type);
-        }
-
-        updateOrientation();
-        window.addEventListener('orientationchange', updateOrientation);
-        return () => {
-            window.removeEventListener('orientationchange', updateOrientation);
-        };
-    }, [screen.orientation.type]);
 
     if (loading) {
         return (
@@ -79,28 +66,7 @@ const GameLayout: React.FC = ({
 
     return (
         <>
-            {orientation.includes('landscape') && (
-                <Flex
-                    justify="center"
-                    align="center"
-                    w="100vw"
-                    h="100vh"
-                    backgroundColor="gray"
-                    px={4}
-                    position={'fixed'}
-                    zIndex={999999}
-                >
-                    <Text
-                        color="white    "
-                        size="xl"
-                        fontWeight="bold"
-                        align={'center'}
-                    >
-                        Please rotate your device to portrait mode to play the
-                        game.
-                    </Text>
-                </Flex>
-            )}
+            <LandscapeScreen />
             <Flex
                 direction="column"
                 w="100vw"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import '@fontsource/poppins';
 import '@fontsource/libre-barcode-39-text';
 import HomeNavBar from './components/HomePage/HomeNavBar';
 import React from 'react';
+import LandscapeScreen from './components/LandscapeScreen';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -28,6 +29,7 @@ export default function RootLayout({
         <html lang="en">
             <body className={inter.className}>
                 <Providers>
+                    <LandscapeScreen />
                     <HomeNavBar />
                     <main>{children}</main>
                 </Providers>


### PR DESCRIPTION
Since it is not possible to lock screen orientation (that supports both android and ios browsers)
- Ive added a check that blocks the whoel screen when mobile device's orientation is landscape in game page

closes #168 