### PR TITLE
create reusable player card, display username #187

### DIFF
--- a/app/components/NavBar/Settings/AcceptedPlayers.tsx
+++ b/app/components/NavBar/Settings/AcceptedPlayers.tsx
@@ -1,8 +1,5 @@
-import { Player } from '@/app/interfaces';
+import { PendingPlayer, Player } from '@/app/interfaces';
 import {
-    Flex,
-    Box,
-    Button,
     Text,
     useDisclosure,
     Modal,
@@ -11,13 +8,14 @@ import {
     ModalHeader,
     ModalBody,
     ModalFooter,
-    Tooltip,
     ModalCloseButton,
+    Button,
 } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import { GiBootKick } from 'react-icons/gi';
-import useToastHelper from '@/app/hooks/useToastHelper';
+
 import useIsTableOwner from '@/app/hooks/useIsTableOwner';
+import PlayerCard from './PlayerCard';
 
 interface Props {
     acceptedPlayers: Player[] | undefined;
@@ -33,10 +31,10 @@ const AcceptedPlayers = ({ acceptedPlayers, handleKickPlayer }: Props) => {
     const [kickingInProgress, setKickingInProgress] = useState<string | null>(
         null
     );
-    const toast = useToastHelper();
+
     const isOwner = useIsTableOwner();
 
-    const confirmKick = (player: Player) => {
+    const confirmKick = (player: PendingPlayer) => {
         setSelectedPlayer({
             uuid: player.uuid,
             name: player.username || player.uuid.substring(0, 8),
@@ -67,149 +65,25 @@ const AcceptedPlayers = ({ acceptedPlayers, handleKickPlayer }: Props) => {
                     if (player) {
                         const isKicking = kickingInProgress === player.uuid;
 
-                        return (
-                            <Flex
-                                key={index}
-                                alignItems={'center'}
-                                gap={{ base: 0, lg: 10 }}
-                                width={{ base: '90vw', md: '70%' }}
-                                borderColor={'grey'}
-                                borderWidth={2}
-                                borderRadius={10}
-                                paddingX={{ base: 5, md: 10 }}
-                                paddingY={{ base: 2, md: 5 }}
-                                direction={{
-                                    base: 'column',
-                                    lg: 'row',
-                                }}
-                                mb={4}
-                                bg={
-                                    isKicking
-                                        ? 'rgba(255, 0, 0, 0.1)'
-                                        : 'transparent'
-                                }
-                                transition="background-color 0.3s"
-                            >
-                                <Flex
-                                    flex={3}
-                                    justifyContent={'space-around'}
-                                    alignItems={'center'}
-                                    textAlign={'left'}
-                                    gap={40}
-                                >
-                                    <Flex
-                                        gap={{ base: 2, xl: 5 }}
-                                        flex={2}
-                                        direction={{
-                                            base: 'column',
-                                            xl: 'row',
-                                        }}
-                                    >
-                                        <Flex
-                                            justifyContent={'space-between'}
-                                            direction={{
-                                                base: 'column',
-                                                xl: 'row',
-                                            }}
-                                            gap={{ base: 2, xl: 5 }}
-                                        >
-                                            <Flex
-                                                gap={{ base: 2, xl: 5 }}
-                                                direction={{
-                                                    base: 'column',
-                                                    xl: 'row',
-                                                }}
-                                            >
-                                                <Box
-                                                    bgColor={'charcoal.600'}
-                                                    paddingY={1}
-                                                    paddingX={2}
-                                                    borderRadius={10}
-                                                >
-                                                    <Text
-                                                        fontSize={'small'}
-                                                        color={'white'}
-                                                    >
-                                                        ID:{' '}
-                                                        {player.uuid.substring(
-                                                            0,
-                                                            8
-                                                        )}
-                                                    </Text>
-                                                </Box>
-                                            </Flex>
-                                            <Text color={'white'}>
-                                                Total buy-in:{' '}
-                                                <Text
-                                                    as={'span'}
-                                                    fontWeight={'bold'}
-                                                >
-                                                    {player.totalBuyIn}
-                                                </Text>
-                                            </Text>
-                                        </Flex>
-                                        <Flex
-                                            gap={4}
-                                            justifyContent={'space-between'}
-                                            direction={{
-                                                base: 'column',
-                                                xl: 'row',
-                                            }}
-                                        >
-                                            <Text color={'white'}>
-                                                Seat:{' '}
-                                                <Text
-                                                    as={'span'}
-                                                    fontWeight={'bold'}
-                                                >
-                                                    {player.seatID}
-                                                </Text>
-                                            </Text>
-                                        </Flex>
-                                    </Flex>
-                                </Flex>
+                        const formattedPlayer: PendingPlayer = {
+                            uuid: player.uuid,
+                            username: player.username,
+                            seatId: player.seatID,
+                            buyIn: player.totalBuyIn,
+                        };
 
-                                <Flex
-                                    gap={{ base: 5, lg: 10 }}
-                                    py={{ base: 5, lg: 0 }}
-                                    width={{ base: '100%', lg: '25%' }}
-                                    justifyContent={{
-                                        base: 'center',
-                                        lg: 'flex-end',
-                                    }}
-                                >
-                                    {isOwner && (
-                                        <Tooltip
-                                            label="Kick Player"
-                                            placement="top"
-                                        >
-                                            <Button
-                                                variant={'settingsSmallButton'}
-                                                bg={'red.500'}
-                                                _hover={{
-                                                    background: 'red.600',
-                                                }}
-                                                onClick={() =>
-                                                    confirmKick(player)
-                                                }
-                                                isLoading={isKicking}
-                                                loadingText="Kicking..."
-                                                width={{
-                                                    base: '100%',
-                                                    lg: 'auto',
-                                                }}
-                                                color="white"
-                                                rightIcon={
-                                                    <GiBootKick size={20} />
-                                                }
-                                                px={4}
-                                            >
-                                                Kick
-                                            </Button>
-                                        </Tooltip>
-                                    )}
-                                </Flex>
-                            </Flex>
+                        return (
+                            <PlayerCard
+                                key={player.uuid}
+                                index={index}
+                                player={formattedPlayer}
+                                isOwner={isOwner}
+                                type={'accepted'}
+                                isKicking={isKicking}
+                                handleAcceptPlayer={null}
+                                handleDenyPlayer={null}
+                                confirmKick={confirmKick}
+                            />
                         );
                     }
                 })}

--- a/app/components/NavBar/Settings/PendingPlayers.tsx
+++ b/app/components/NavBar/Settings/PendingPlayers.tsx
@@ -1,8 +1,9 @@
 import useIsTableOwner from '@/app/hooks/useIsTableOwner';
 import { PendingPlayer } from '@/app/interfaces';
-import { Flex, Box, Button, Text } from '@chakra-ui/react';
+import { Text } from '@chakra-ui/react';
 import React from 'react';
-import { FaCircleCheck, FaCircleXmark } from 'react-icons/fa6';
+
+import PlayerCard from './PlayerCard';
 
 interface Props {
     pendingPlayers: PendingPlayer[];
@@ -20,134 +21,23 @@ const PendingPlayers = ({
     if (pendingPlayers && pendingPlayers.length > 0) {
         return (
             <>
-                <Text color={'white'}>Pending</Text>
+                <Text color={'white'} fontSize="lg" fontWeight="bold" mb={4}>
+                    Pending
+                </Text>
                 {pendingPlayers.map((player: PendingPlayer, index: number) => {
                     if (player) {
                         return (
-                            <Flex
-                                key={index}
-                                alignItems={'center'}
-                                gap={{ base: 0, lg: 10 }}
-                                width={{ base: '90vw', md: '70%' }}
-                                borderColor={'grey'}
-                                borderWidth={2}
-                                borderRadius={10}
-                                paddingX={{ base: 5, md: 10 }}
-                                paddingY={{ base: 2, md: 5 }}
-                                direction={{
-                                    base: 'column',
-                                    lg: 'row',
-                                }}
-                            >
-                                <Flex
-                                    flex={3}
-                                    justifyContent={'space-around'}
-                                    alignItems={'center'}
-                                    textAlign={'left'}
-                                    gap={40}
-                                >
-                                    <Flex
-                                        gap={{ base: 2, xl: 5 }}
-                                        flex={2}
-                                        direction={{
-                                            base: 'column',
-                                            xl: 'row',
-                                        }}
-                                    >
-                                        <Flex
-                                            justifyContent={'space-between'}
-                                            direction={{
-                                                base: 'column',
-                                                xl: 'row',
-                                            }}
-                                            gap={{ base: 2, xl: 5 }}
-                                        >
-                                            <Flex
-                                                gap={{ base: 2, xl: 5 }}
-                                                direction={{
-                                                    base: 'column',
-                                                    xl: 'row',
-                                                }}
-                                            >
-                                                <Box
-                                                    bgColor={'charcoal.600'}
-                                                    paddingY={1}
-                                                    paddingX={2}
-                                                    borderRadius={10}
-                                                >
-                                                    <Text
-                                                        fontSize={'small'}
-                                                        color={'white'}
-                                                    >
-                                                        ID:{' '}
-                                                        {player.uuid.substring(
-                                                            0,
-                                                            8
-                                                        )}
-                                                    </Text>
-                                                </Box>
-                                            </Flex>
-                                            <Text color={'white'}>
-                                                Total buy-in:{' '}
-                                                <Text
-                                                    as={'span'}
-                                                    fontWeight={'bold'}
-                                                >
-                                                    {player.buyIn}
-                                                </Text>
-                                            </Text>
-                                        </Flex>
-                                        <Flex
-                                            gap={4}
-                                            justifyContent={'space-between'}
-                                            direction={{
-                                                base: 'column',
-                                                xl: 'row',
-                                            }}
-                                        >
-                                            <Text color={'white'}>
-                                                Seat:{' '}
-                                                <Text
-                                                    as={'span'}
-                                                    fontWeight={'bold'}
-                                                >
-                                                    {player.seatId}
-                                                </Text>
-                                            </Text>
-                                        </Flex>
-                                    </Flex>
-                                </Flex>
-
-                                {isOwner && (
-                                    <Flex
-                                        gap={{ base: 5, lg: 10 }}
-                                        py={{ base: 5, lg: 0 }}
-                                        width={'20%'}
-                                        justifyContent={'space-between'}
-                                    >
-                                        <Button
-                                            variant={'settingsSmallButton'}
-                                            bg={'green.500'}
-                                            _hover={{ background: 'green' }}
-                                            onClick={() =>
-                                                handleAcceptPlayer(player.uuid)
-                                            }
-                                        >
-                                            <FaCircleCheck />
-                                        </Button>
-                                        <Button
-                                            variant={'settingsSmallButton'}
-                                            bg={'red.500'}
-                                            _hover={{ background: 'red' }}
-                                            onClick={() =>
-                                                handleDenyPlayer(player.uuid)
-                                            }
-                                        >
-                                            <FaCircleXmark />
-                                        </Button>
-                                    </Flex>
-                                )}
-                            </Flex>
+                            <PlayerCard
+                                key={player.uuid}
+                                index={index}
+                                player={player}
+                                isOwner={isOwner}
+                                type={'pending'}
+                                isKicking={null}
+                                handleAcceptPlayer={handleAcceptPlayer}
+                                handleDenyPlayer={handleDenyPlayer}
+                                confirmKick={null}
+                            />
                         );
                     }
                 })}

--- a/app/components/NavBar/Settings/PlayerCard.tsx
+++ b/app/components/NavBar/Settings/PlayerCard.tsx
@@ -1,0 +1,159 @@
+import { PendingPlayer } from '@/app/interfaces';
+import { Flex, Box, Button, Text, Tooltip, VStack } from '@chakra-ui/react';
+import { FaCircleCheck, FaCircleXmark } from 'react-icons/fa6';
+import { GiBootKick } from 'react-icons/gi';
+
+const PlayerCard = ({
+    index,
+    player,
+    isOwner,
+    type,
+    isKicking,
+    handleAcceptPlayer,
+    handleDenyPlayer,
+    confirmKick,
+}: {
+    index: number;
+    player: PendingPlayer;
+    isOwner: boolean;
+    type: 'accepted' | 'pending';
+    isKicking: boolean | null;
+    handleAcceptPlayer?: ((uuid: string) => void) | null;
+    handleDenyPlayer?: ((uuid: string) => void) | null;
+    confirmKick?: ((player: PendingPlayer) => void) | null;
+}) => {
+    return (
+        <Flex
+            key={index}
+            alignItems={'center'}
+            justifyContent={'space-between'}
+            width={{ base: '90vw', md: '70%' }}
+            borderColor={'grey'}
+            borderWidth={2}
+            borderRadius={10}
+            paddingX={{ base: 5, md: 10 }}
+            paddingY={{ base: 2, md: 5 }}
+        >
+            <VStack
+                flex={1}
+                justifyContent={{ base: 'center', lg: 'space-around' }}
+                alignItems={'start'}
+                textAlign={'left'}
+                gap={2}
+            >
+                <Text
+                    color={'white'}
+                    fontWeight={'bold'}
+                    fontSize={{ base: 'xl', lg: '2xl' }}
+                >
+                    {player.username}
+                </Text>
+                <Flex
+                    gap={{ base: 2, xl: 5 }}
+                    flex={2}
+                    direction={{
+                        base: 'column',
+                        xl: 'row',
+                    }}
+                >
+                    <Flex
+                        justifyContent={'space-between'}
+                        direction={{
+                            base: 'column',
+                            xl: 'row',
+                        }}
+                        gap={{ base: 2, xl: 5 }}
+                    >
+                        <Flex
+                            gap={{ base: 2, xl: 5 }}
+                            direction={{
+                                base: 'column',
+                                xl: 'row',
+                            }}
+                        >
+                            <Box
+                                bgColor={'charcoal.600'}
+                                paddingY={1}
+                                paddingX={2}
+                                borderRadius={10}
+                            >
+                                <Text fontSize={'small'} color={'white'}>
+                                    ID: {player.uuid.substring(0, 8)}
+                                </Text>
+                            </Box>
+                        </Flex>
+                        <Text color={'white'}>
+                            Total buy-in:{' '}
+                            <Text as={'span'} fontWeight={'bold'}>
+                                {player.buyIn}
+                            </Text>
+                        </Text>
+                    </Flex>
+                    <Flex
+                        gap={4}
+                        justifyContent={'space-between'}
+                        direction={{
+                            base: 'column',
+                            xl: 'row',
+                        }}
+                    >
+                        <Text color={'white'}>
+                            Seat:{' '}
+                            <Text as={'span'} fontWeight={'bold'}>
+                                {player.seatId}
+                            </Text>
+                        </Text>
+                    </Flex>
+                </Flex>
+            </VStack>
+
+            {isOwner &&
+                type == 'pending' &&
+                handleAcceptPlayer &&
+                handleDenyPlayer && (
+                    <Flex gap={{ base: 2, lg: 3 }} py={{ base: 3, lg: 0 }}>
+                        <Button
+                            variant={'settingsSmallButton'}
+                            bg={'green.500'}
+                            _hover={{ background: 'green' }}
+                            onClick={() => handleAcceptPlayer(player.uuid)}
+                        >
+                            <FaCircleCheck />
+                        </Button>
+                        <Button
+                            variant={'settingsSmallButton'}
+                            bg={'red.500'}
+                            _hover={{ background: 'red' }}
+                            onClick={() => handleDenyPlayer(player.uuid)}
+                        >
+                            <FaCircleXmark />
+                        </Button>
+                    </Flex>
+                )}
+
+            {isOwner &&
+                type == 'accepted' &&
+                isKicking !== null &&
+                confirmKick && (
+                    <Tooltip label="Kick Player" placement="top">
+                        <Button
+                            variant={'settingsSmallButton'}
+                            bg={'red.500'}
+                            _hover={{
+                                background: 'red.600',
+                            }}
+                            onClick={() => confirmKick(player)}
+                            isLoading={isKicking}
+                            loadingText="Kicking..."
+                            color="white"
+                            my={{ base: 3, lg: 6 }}
+                        >
+                            <GiBootKick size={20} />
+                        </Button>
+                    </Tooltip>
+                )}
+        </Flex>
+    );
+};
+
+export default PlayerCard;

--- a/app/theme.ts
+++ b/app/theme.ts
@@ -224,7 +224,7 @@ const components = {
                 border: 0,
             },
             settingsSmallButton: {
-                width: '50%',
+                width: '50px',
                 border: 0,
             },
             connectButton: {


### PR DESCRIPTION
## Changes

`AcceptedPlayers.tsx`
- confirmKick function now accepts a PendingPlayer instead of a Player.
- Replaced large inline JSX player display with PlayerCard.
- Before rendering, transforms Player into PendingPlayer shape (uuid, username, seatId, buyIn).

`PendingPlayers.tsx`
- Replaced inline JSX layout for each player with PlayerCard.

`PlayerCard.tsx (new file)`
- New reusable component for player display.
- Props:
   - index, player (PendingPlayer), isOwner, type ('accepted' | 'pending').
   - Optional: isKicking, handleAcceptPlayer, handleDenyPlayer, confirmKick.
- Displays player details: username, short UUID, buy-in, and seat.
- Adjusted action buttons to be the same size always.

## After  Changes Result

Mobile:
<img width="742" height="917" alt="image" src="https://github.com/user-attachments/assets/bdfe42e9-e2ac-4a5f-9a09-f9f93f4fbb5b" />

Tablet:
<img width="677" height="851" alt="image" src="https://github.com/user-attachments/assets/37f9a66a-5d97-46ee-a56d-1ad6c8912637" />

Desktop:
<img width="1864" height="923" alt="image" src="https://github.com/user-attachments/assets/4b6b62ab-0424-44e5-aa4f-c8bb8058a318" />

## Before Changes

Mobile:
<img width="730" height="913" alt="image" src="https://github.com/user-attachments/assets/3e248154-7959-4c85-b5c4-c96ea5c8da7b" />

Tablet:
<img width="727" height="868" alt="image" src="https://github.com/user-attachments/assets/268dd305-67e4-4f8a-9803-8d918c902a79" />

Desktop:
<img width="1864" height="927" alt="image" src="https://github.com/user-attachments/assets/7810b8ea-8326-49b6-a914-cdd0b8939685" />

Closes #187 