### PR TITLE
Allow pending player to cancel request

### DIFF
--- a/app/components/Footer/CancelSeatRequestButton.tsx
+++ b/app/components/Footer/CancelSeatRequestButton.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { AppContext } from '@/app/contexts/AppStoreProvider';
+import { SocketContext } from '@/app/contexts/WebSocketProvider';
+import { cancelSeatRequest } from '@/app/hooks/server_actions';
+import { Button } from '@chakra-ui/react';
+import { useContext } from 'react';
+
+const CancelSeatRequestButton = () => {
+    const socket = useContext(SocketContext);
+    const { appState } = useContext(AppContext);
+
+    if (!socket || !appState.clientID || appState.seatRequested === null) {
+        return null;
+    }
+
+    return (
+        <Button
+            position="fixed"
+            bottom="2"
+            right="2"
+            bg="red.400"
+            width="fit-content"
+            alignSelf="end"
+            m={4}
+            onClick={() => {
+                cancelSeatRequest(socket);
+            }}
+        >
+            Cancel Request ({appState.seatRequested})
+        </Button>
+    );
+};
+
+export default CancelSeatRequestButton;

--- a/app/components/Footer/EmptyFooter.tsx
+++ b/app/components/Footer/EmptyFooter.tsx
@@ -1,4 +1,5 @@
 import { Flex } from '@chakra-ui/react';
+import CancelSeatRequestButton from './CancelSeatRequestButton';
 
 const EmptyFooter = () => {
     return (
@@ -8,7 +9,9 @@ const EmptyFooter = () => {
             p={2}
             height={{ base: '100px', md: '150px' }}
             overflow={'hidden'}
-        />
+        >
+            <CancelSeatRequestButton />
+        </Flex>
     );
 };
 

--- a/app/components/Footer/FooterWithActionButtons.tsx
+++ b/app/components/Footer/FooterWithActionButtons.tsx
@@ -66,7 +66,7 @@ const FooterWithActionButtons = ({
                     }
                     break;
                 case HOTKEY_FOLD:
-                    handleFold(appState.username);
+                    canCheck ? onOpen() : handleFold(appState.username);
                     e.preventDefault();
                     break;
                 default:

--- a/app/components/GuardModal.tsx
+++ b/app/components/GuardModal.tsx
@@ -50,6 +50,7 @@ const GuardModal = ({
                     onClick={() => {
                         if (username) {
                             handleFold(username);
+                            onClose();
                         }
                     }}
                 >

--- a/app/components/Table.tsx
+++ b/app/components/Table.tsx
@@ -323,7 +323,7 @@ const Table = () => {
                                                 (player) =>
                                                     player.uuid ===
                                                     appState.clientID
-                                            ) || appState.isSeatRequested
+                                            ) || appState.seatRequested != null
                                         }
                                     />
                                 )}

--- a/app/components/TakeSeatModal.tsx
+++ b/app/components/TakeSeatModal.tsx
@@ -90,7 +90,7 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
         newPlayer(socket, name);
         takeSeat(socket, name, seatId, buyIn);
         appStore.dispatch({ type: 'setUsername', payload: name });
-        appStore.dispatch({ type: 'setIsSeatRequested', payload: true });
+        appStore.dispatch({ type: 'setSeatRequested', payload: seatId });
         currentUser.setCurrentUser({ name, seatId });
         sendLog(socket, `${name} buys in for ${buyIn}`);
         onClose(); // Close modal after sending

--- a/app/contexts/AppStoreProvider.tsx
+++ b/app/contexts/AppStoreProvider.tsx
@@ -12,7 +12,7 @@ const initialState: AppState = {
     volume: 1,
     unreadMessageCount: 0,
     isChatOpen: false,
-    isSeatRequested: false,
+    seatRequested: null,
     isLeaveRequested: false,
     pendingPlayers: [],
 };
@@ -29,7 +29,7 @@ type ACTIONTYPE =
     | { type: 'incrementUnreadCount' }
     | { type: 'resetUnreadCount' }
     | { type: 'setChatOpen'; payload: boolean }
-    | { type: 'setIsSeatRequested'; payload: boolean }
+    | { type: 'setSeatRequested'; payload: number | null }
     | { type: 'setIsLeaveRequested'; payload: boolean }
     | { type: 'setPendingPlayers'; payload: PendingPlayer[] };
 
@@ -76,8 +76,8 @@ function reducer(state: AppState, action: ACTIONTYPE) {
                 };
             }
             return { ...state, isChatOpen: action.payload };
-        case 'setIsSeatRequested':
-            return { ...state, isSeatRequested: action.payload };
+        case 'setSeatRequested':
+            return { ...state, seatRequested: action.payload };
         case 'setIsLeaveRequested':
             return { ...state, isLeaveRequested: action.payload };
         case 'setPendingPlayers':

--- a/app/contexts/WebSocketProvider.tsx
+++ b/app/contexts/WebSocketProvider.tsx
@@ -232,7 +232,7 @@ export function SocketProvider(props: SocketProviderProps) {
                     // Handle is_pending_player message
                     if (eventData.payload !== undefined) {
                         dispatch({
-                            type: 'setIsSeatRequested',
+                            type: 'setSeatRequested',
                             payload: eventData.payload, // true if the player is pending, false otherwise
                         });
                     } else {
@@ -241,8 +241,8 @@ export function SocketProvider(props: SocketProviderProps) {
                             eventData.payload
                         );
                         dispatch({
-                            type: 'setIsSeatRequested',
-                            payload: false,
+                            type: 'setSeatRequested',
+                            payload: null,
                         });
                         return; // Message handled
                     }
@@ -317,11 +317,11 @@ export function SocketProvider(props: SocketProviderProps) {
                         );
                         if (
                             isPlayerSeated &&
-                            appStateRef.current.isSeatRequested
+                            appStateRef.current.seatRequested
                         ) {
                             dispatch({
-                                type: 'setIsSeatRequested',
-                                payload: false,
+                                type: 'setSeatRequested',
+                                payload: null,
                             });
                         }
                         return;
@@ -381,11 +381,11 @@ export function SocketProvider(props: SocketProviderProps) {
                             (eventData.message === 'Seat request denied.' ||
                                 eventData.message ===
                                     'A player is already requesting for this seat.') &&
-                            appStateRef.current.isSeatRequested
+                            appStateRef.current.seatRequested
                         ) {
                             dispatch({
-                                type: 'setIsSeatRequested',
-                                payload: false,
+                                type: 'setSeatRequested',
+                                payload: null,
                             });
                         }
                         return;

--- a/app/hooks/server_actions.ts
+++ b/app/hooks/server_actions.ts
@@ -83,6 +83,13 @@ export function resetGame(socket: WebSocket) {
     });
 }
 
+export function cancelPlayer(socket: WebSocket, uuid: string) {
+    sendWebSocketMessage(socket, {
+        action: 'cancel-player',
+        uuid: uuid,
+    });
+}
+
 // export function dealGame(socket: WebSocket) {
 //     socket.send(
 //         JSON.stringify({

--- a/app/hooks/server_actions.ts
+++ b/app/hooks/server_actions.ts
@@ -83,10 +83,9 @@ export function resetGame(socket: WebSocket) {
     });
 }
 
-export function cancelPlayer(socket: WebSocket, uuid: string) {
+export function cancelSeatRequest(socket: WebSocket) {
     sendWebSocketMessage(socket, {
-        action: 'cancel-player',
-        uuid: uuid,
+        action: 'cancel-seat-request',
     });
 }
 

--- a/app/interfaces.tsx
+++ b/app/interfaces.tsx
@@ -22,7 +22,7 @@ export type AppState = {
     volume: number;
     unreadMessageCount: number;
     isChatOpen: boolean; // Track if chat is currently open
-    isSeatRequested: boolean;
+    seatRequested: number | null;
     isLeaveRequested: boolean;
     pendingPlayers: PendingPlayer[]; // Added for storing pending players
 };

--- a/app/table/[id]/page.tsx
+++ b/app/table/[id]/page.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { useEffect, useState, useContext } from 'react';
-import { cancelPlayer, isTableExisting } from '@/app/hooks/server_actions';
+import { isTableExisting } from '@/app/hooks/server_actions';
 import Table from '@/app/components/Table';
 import { AppContext } from '@/app/contexts/AppStoreProvider';
-import { Box, Button, Flex, Heading } from '@chakra-ui/react';
+import { Box, Flex, Heading } from '@chakra-ui/react';
 import { useRouter } from 'next/navigation';
 import useToastHelper from '@/app/hooks/useToastHelper';
-import { SocketContext } from '@/app/contexts/WebSocketProvider';
 
 const TablePage = ({ params }: { params: { id: string } }) => {
     const router = useRouter();
@@ -16,7 +15,6 @@ const TablePage = ({ params }: { params: { id: string } }) => {
     const [tableStatus, setTableStatus] = useState<'checking' | 'success'>(
         'checking'
     );
-    const socket = useContext(SocketContext);
     const tableId = params.id;
 
     useEffect(() => {
@@ -80,26 +78,6 @@ const TablePage = ({ params }: { params: { id: string } }) => {
                 }}
             >
                 <Table />
-                {socket &&
-                    appState.clientID &&
-                    appState.seatRequested !== null && (
-                        <Button
-                            position="fixed"
-                            bottom="2"
-                            right="2"
-                            bg={'red.400'}
-                            width={'fit-content'}
-                            alignSelf={'end'}
-                            m={4}
-                            onClick={() => {
-                                if (appState.clientID) {
-                                    cancelPlayer(socket, appState.clientID);
-                                }
-                            }}
-                        >
-                            Cancel Request ({appState.seatRequested})
-                        </Button>
-                    )}
             </Flex>
         </>
     );

--- a/app/table/[id]/page.tsx
+++ b/app/table/[id]/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useEffect, useState, useContext } from 'react';
-import { isTableExisting } from '@/app/hooks/server_actions';
+import { cancelPlayer, isTableExisting } from '@/app/hooks/server_actions';
 import Table from '@/app/components/Table';
 import { AppContext } from '@/app/contexts/AppStoreProvider';
-import { Box, Flex, Heading } from '@chakra-ui/react';
+import { Box, Button, Flex, Heading } from '@chakra-ui/react';
 import { useRouter } from 'next/navigation';
 import useToastHelper from '@/app/hooks/useToastHelper';
+import { SocketContext } from '@/app/contexts/WebSocketProvider';
 
 const TablePage = ({ params }: { params: { id: string } }) => {
     const router = useRouter();
@@ -15,7 +16,7 @@ const TablePage = ({ params }: { params: { id: string } }) => {
     const [tableStatus, setTableStatus] = useState<'checking' | 'success'>(
         'checking'
     );
-
+    const socket = useContext(SocketContext);
     const tableId = params.id;
 
     useEffect(() => {
@@ -79,6 +80,26 @@ const TablePage = ({ params }: { params: { id: string } }) => {
                 }}
             >
                 <Table />
+                {socket &&
+                    appState.clientID &&
+                    appState.seatRequested !== null && (
+                        <Button
+                            position="fixed"
+                            bottom="2"
+                            right="2"
+                            bg={'red.400'}
+                            width={'fit-content'}
+                            alignSelf={'end'}
+                            m={4}
+                            onClick={() => {
+                                if (appState.clientID) {
+                                    cancelPlayer(socket, appState.clientID);
+                                }
+                            }}
+                        >
+                            Cancel Request ({appState.seatRequested})
+                        </Button>
+                    )}
             </Flex>
         </>
     );


### PR DESCRIPTION
### Changes Summary

`app/components/Table.tsx`
- Updated seat disable check: replaced appState.isSeatRequested with appState.seatRequested != null.

`app/components/TakeSeatModal.tsx`
- Changed dispatch from setIsSeatRequested: true to setSeatRequested: seatId.

`app/contexts/AppStoreProvider.tsx`
- Updated initial state: isSeatRequested: false → seatRequested: null.
- Replaced action type setIsSeatRequested: boolean with setSeatRequested: number | null.
- Updated reducer to handle seatRequested instead of isSeatRequested.

`app/contexts/WebSocketProvider.tsx`
- Replaced all dispatches of setIsSeatRequested with setSeatRequested.
- Changed payload from boolean to seatId | null.
- Adjusted state checks to use seatRequested instead of isSeatRequested.

`app/hooks/server_actions.ts`
- Added new function cancelPlayer(socket, uuid) that sends a cancel-player action.

`app/interfaces.tsx`
- Changed AppState.isSeatRequested: boolean → AppState.seatRequested: number | null.

`app/table/[id]/page.tsx`
- Imported cancelPlayer and SocketContext.
- Added Cancel Request button:
   - Shown if seatRequested !== null.
   - Calls cancelPlayer with clientID.

### Related Issue

Backend: https://github.com/Stacked-Labs/poker-server/pull/61

### Test Results

#### Requesting Player's view

Desktop:
<img width="1879" height="931" alt="image" src="https://github.com/user-attachments/assets/12bab162-1c58-4170-ad6d-a7dbca0f871d" />

Tablet:
<img width="686" height="863" alt="image" src="https://github.com/user-attachments/assets/1007cf51-0691-4288-b342-df53ba236e0c" />

Mobile:
<img width="688" height="913" alt="image" src="https://github.com/user-attachments/assets/ca3bc502-d953-41ac-b38f-c2e5e403dfb2" />

A modal pops up once player clicks cancel request button:
<img width="1873" height="929" alt="image" src="https://github.com/user-attachments/assets/a5c63f10-3986-4b28-ad3c-5d23b8fb0b39" />

Closes #186