### PR TITLE
fix navbar unclickable areas #224

### DIFF
--- a/app/components/NavBar/index.tsx
+++ b/app/components/NavBar/index.tsx
@@ -120,7 +120,7 @@ const Navbar = ({ isLoading }: { isLoading: boolean }) => {
                 justify="space-between"
                 wrap="wrap"
                 padding={{ base: '0.75rem 1rem', md: '1rem 1.5rem' }}
-                bg="transparent"
+                bg="none"
                 color="text.secondary"
                 zIndex={99}
                 opacity={isLoading ? 0 : 1}
@@ -130,8 +130,13 @@ const Navbar = ({ isLoading }: { isLoading: boolean }) => {
                 position="fixed"
                 top={0}
                 width="100%"
+                pointerEvents={'none'}
             >
-                <HStack spacing={{ base: 1, md: 2 }} alignItems="stretch">
+                <HStack
+                    spacing={{ base: 1, md: 2 }}
+                    alignItems="stretch"
+                    pointerEvents={'auto'}
+                >
                     <TableMenuBurger
                         isUserSeated={isUserSeated}
                         isAway={isAway}
@@ -249,7 +254,11 @@ const Navbar = ({ isLoading }: { isLoading: boolean }) => {
                         <ColorModeButton />
                     </Box>
                 </HStack>
-                <HStack spacing={{ base: 1, md: 2 }} alignItems="center">
+                <HStack
+                    spacing={{ base: 1, md: 2 }}
+                    alignItems="center"
+                    pointerEvents={'auto'}
+                >
                     <Box display={{ base: 'none', md: 'block' }}>
                         <VolumeButton />
                     </Box>


### PR DESCRIPTION
## Test Results

Seats now clickable:

<img width="1920" height="1032" alt="Image" src="https://github.com/user-attachments/assets/11df6899-62a0-4415-9679-c8246cbe40d7" />

Navbar buttons still clickable:

<img width="1920" height="1032" alt="Image" src="https://github.com/user-attachments/assets/a5b53b7b-7ed4-4cc4-8784-01529ca0cda9" />

<img width="1920" height="1032" alt="Image" src="https://github.com/user-attachments/assets/7bc54778-4fcc-409f-a148-b560cbed3c20" />

Closes #224