### PR TITLE
Hand reveal feature

### DIFF
--- a/app/components/Footer/ShowCardsFooter.tsx
+++ b/app/components/Footer/ShowCardsFooter.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Flex } from '@chakra-ui/react';
+import ActionButton from './ActionButton';
+import SeatRequestStatusBadge from './SeatRequestStatusBadge';
+
+type ShowCardsFooterProps = {
+    onShowCards: () => void;
+    isDisabled: boolean;
+};
+
+const ShowCardsFooter = ({ onShowCards, isDisabled }: ShowCardsFooterProps) => {
+    return (
+        <Flex
+            className="footer-show-cards"
+            overflow="visible"
+            alignItems="center"
+            bg="transparent"
+            width="100%"
+            position="relative"
+            sx={{
+                '@media (orientation: portrait)': {
+                    justifyContent: 'space-between',
+                    gap: '1%',
+                    padding: '1%',
+                    height: '100%',
+                    maxHeight: '70px',
+                    minHeight: '50px',
+                },
+                '@media (orientation: landscape)': {
+                    justifyContent: 'flex-end',
+                    gap: '0.8%',
+                    height: '100%',
+                },
+            }}
+        >
+            <ActionButton
+                text="Show Cards"
+                color="green"
+                clickHandler={onShowCards}
+                isDisabled={isDisabled}
+                hotkey=""
+            />
+            <SeatRequestStatusBadge />
+        </Flex>
+    );
+};
+
+export default ShowCardsFooter;
+

--- a/app/components/NavBar/Settings/GameLog.tsx
+++ b/app/components/NavBar/Settings/GameLog.tsx
@@ -92,6 +92,13 @@ interface PlayerEliminatedMetadata {
     hand_number?: number;
 }
 
+interface PlayerRevealedCardsMetadata {
+    hole_cards?: [string, string] | string[];
+    hand_number?: number;
+    seat_id?: number;
+    player_uuid?: string;
+}
+
 // Helper function to convert backend card string to EvalCard format
 const convertBackendCardToInt = (cardStr: string): EvalCard | null => {
     if (!cardStr || cardStr.length < 2) return null;
@@ -811,6 +818,63 @@ const GameLog = () => {
                             <> before Hand #{handRef}</>
                         )}
                     </>
+                );
+            }
+
+            case 'player_revealed_cards': {
+                const meta = metadata as Partial<PlayerRevealedCardsMetadata>;
+                const displayName = player_name || 'Player';
+                const cards = Array.isArray(meta.hole_cards)
+                    ? meta.hole_cards
+                    : null;
+
+                return (
+                    <Box>
+                        <Text as="span" fontWeight="bold" color="text.primary">
+                            {displayName}{' '}
+                            <Text
+                                as="span"
+                                color="purple.600"
+                                fontWeight="bold"
+                            >
+                                revealed
+                            </Text>{' '}
+                            cards
+                            {cards && cards.length > 0 ? (
+                                <>
+                                    :{' '}
+                                    <Text
+                                        as="span"
+                                        color="text.secondary"
+                                        fontWeight="bold"
+                                    >
+                                        {convertCardsToEmojis(cards)}
+                                    </Text>
+                                </>
+                            ) : null}
+                        </Text>
+                        {(meta.hand_number !== undefined ||
+                            meta.seat_id !== undefined) && (
+                            <Text
+                                fontSize="xs"
+                                color="text.gray600"
+                                mt={0.5}
+                                ml={4}
+                                fontWeight="bold"
+                            >
+                                {meta.hand_number !== undefined
+                                    ? `Hand #${meta.hand_number}`
+                                    : null}
+                                {meta.hand_number !== undefined &&
+                                meta.seat_id !== undefined
+                                    ? ' • '
+                                    : null}
+                                {meta.seat_id !== undefined
+                                    ? `Seat ${meta.seat_id}`
+                                    : null}
+                            </Text>
+                        )}
+                    </Box>
                 );
             }
 

--- a/app/components/TakenSeatButton.tsx
+++ b/app/components/TakenSeatButton.tsx
@@ -569,12 +569,18 @@ const TakenSeatButton = ({
                             ? player.uuid === appState.clientID
                             : false;
 
-                        // Determine if we are in showdown state
+                        const game = appState.game;
+
+                        // Determine if we are in showdown/reveal window state (hand ended, before next hand starts)
                         const isShowdown = Boolean(
-                            appState.game &&
-                                appState.game.stage === 1 &&
-                                !appState.game.betting &&
-                                (appState.game.pots?.length || 0) > 0
+                            game &&
+                                game.stage === 1 &&
+                                !game.betting &&
+                                (game.actionDeadline ?? 0) === 0 &&
+                                ((game.pots?.length || 0) > 0 ||
+                                    (game.communityCards || []).some(
+                                        (card) => Number(card) > 0
+                                    ))
                         );
 
                         // Check if player has real (revealed) cards - not [0,0] or [-1,-1]

--- a/app/hooks/server_actions.ts
+++ b/app/hooks/server_actions.ts
@@ -122,6 +122,12 @@ export function playerFold(socket: WebSocket) {
     });
 }
 
+export function revealCards(socket: WebSocket) {
+    sendWebSocketMessage(socket, {
+        action: 'reveal-cards',
+    });
+}
+
 export function requestLeave(socket: WebSocket) {
     sendWebSocketMessage(socket, {
         action: 'request-leave',

--- a/app/interfaces.tsx
+++ b/app/interfaces.tsx
@@ -51,6 +51,7 @@ export type Player = {
     bet: number;
     totalBet: number;
     cards: string[];
+    hasRevealed?: boolean;
     readyNextHand?: boolean;
     sitOutNextHand?: boolean;
     leaveAfterHand?: boolean;
@@ -131,6 +132,7 @@ export type EventType =
     | 'player_set_ready'
     | 'player_set_away'
     | 'player_eliminated'
+    | 'player_revealed_cards'
     // Game events
     | 'hand_started'
     | 'cards_dealt'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a controlled post-hand reveal window and UI to let players reveal their hole cards and log the action.
> 
> - New `ShowCardsFooter` with "Show Cards" button; rendered in `Footer` only during the reveal window (`stage === 1`, not betting, `actionDeadline === 0`), disabled after submission or if `player.hasRevealed`
> - Adds `revealCards(socket)` in `hooks/server_actions.ts` to send `action: 'reveal-cards'`
> - Updates `TakenSeatButton` showdown detection to align with reveal window and render/dim cards appropriately (including non-winners and winners by fold)
> - Extends `GameLog` to handle `player_revealed_cards` and display revealed hole cards with optional hand/seat metadata
> - Extends types: `Player.hasRevealed?` and `EventType` includes `player_revealed_cards`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64d20266d3f43e5f5aec85368a604d58a19cc0ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->