### PR TITLE
Add manual playback fallback for video autoplay

### DIFF
--- a/app/components/HomePage/FeaturesSection.tsx
+++ b/app/components/HomePage/FeaturesSection.tsx
@@ -178,22 +178,31 @@ const FeaturesSection = () => {
 
         let playAttempts = 0;
         const maxAttempts = 5;
+        const timeoutIds: NodeJS.Timeout[] = [];
+        let isMounted = true;
 
         const tryPlay = async () => {
+            if (!isMounted) return;
+
             try {
                 await video.play();
-                setIsPlaying(true);
+                if (isMounted) {
+                    setIsPlaying(true);
+                }
             } catch (error) {
                 // Retry autoplay if it was blocked
-                if (playAttempts < maxAttempts) {
+                if (playAttempts < maxAttempts && isMounted) {
                     playAttempts++;
-                    setTimeout(tryPlay, 200 * playAttempts);
+                    const timeoutId = setTimeout(tryPlay, 200 * playAttempts);
+                    timeoutIds.push(timeoutId);
                 }
             }
         };
 
         const handleError = () => {
-            setVideoFailed(true);
+            if (isMounted) {
+                setVideoFailed(true);
+            }
         };
 
         const handleCanPlay = () => {
@@ -205,11 +214,15 @@ const FeaturesSection = () => {
         };
 
         const handlePlay = () => {
-            setIsPlaying(true);
+            if (isMounted) {
+                setIsPlaying(true);
+            }
         };
 
         const handlePause = () => {
-            setIsPlaying(false);
+            if (isMounted) {
+                setIsPlaying(false);
+            }
         };
 
         video.addEventListener('canplay', handleCanPlay);
@@ -224,6 +237,8 @@ const FeaturesSection = () => {
         }
 
         return () => {
+            isMounted = false;
+            timeoutIds.forEach(clearTimeout);
             video.removeEventListener('canplay', handleCanPlay);
             video.removeEventListener('loadeddata', handleLoadedData);
             video.removeEventListener('error', handleError);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only changes limited to homepage video playback; main risk is minor behavioral differences across browsers due to new retry/event handling.
> 
> **Overview**
> Improves the homepage iPhone demo video autoplay behavior in `FeaturesSection` by adding **bounded retry logic** (with cleanup) and responding to additional media events (`loadeddata`, `play`, `pause`) to keep an `isPlaying` state in sync.
> 
> Adds a **manual click-to-play fallback** and pointer cursor when the video isn’t playing, and updates the video to `preload="auto"` to reduce cases where playback never starts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ebdc1f92b3d8c6c2fc05d0a4ea140ed577f2e86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->