### PR TITLE
Guard for deposit wallet mismatch

### DIFF
--- a/app/components/TakeSeatModal.tsx
+++ b/app/components/TakeSeatModal.tsx
@@ -92,7 +92,7 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
     const initialBuyIn = config?.maxBuyIn ?? null;
     const currentUser = useCurrentUser();
     const socket = useContext(SocketContext);
-    const { isAuthenticated, isAuthenticating } = useAuth();
+    const { isAuthenticated, isAuthenticating, lastAuthenticatedAddress } = useAuth();
     const [name, setName] = useState('');
     const [buyIn, setBuyIn] = useState<number | null>(initialBuyIn);
     const [buyInInput, setBuyInInput] = useState(() => {
@@ -234,6 +234,18 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
         if (isCryptoGame) {
             if (!contractAddress) {
                 error('Contract Error', 'Game contract address not available.');
+                return;
+            }
+
+            // Guard: active wallet must match the authenticated JWT wallet.
+            // If they differ, the on-chain tx would come from a different address
+            // than the one the backend has on record, causing the deposit to be
+            // treated as a stranger's seat request instead of the owner's.
+            if (address?.toLowerCase() !== lastAuthenticatedAddress?.toLowerCase()) {
+                error(
+                    'Wallet Mismatch',
+                    `Your active wallet doesn't match your authenticated session. Switch back to ${lastAuthenticatedAddress ? lastAuthenticatedAddress.slice(0, 6) + '...' + lastAuthenticatedAddress.slice(-4) : 'your original wallet'} or re-authenticate.`
+                );
                 return;
             }
 

--- a/app/components/TakenSeatButton.tsx
+++ b/app/components/TakenSeatButton.tsx
@@ -13,7 +13,6 @@ import {
     ResponsiveValue,
     HStack,
     Progress,
-    Tooltip,
     Tag,
     Icon,
     IconButton,
@@ -1268,14 +1267,7 @@ const TakenSeatButton = ({
                                     gap={{ base: 1 }}
                                     minWidth={0}
                                 >
-                                    <Tooltip
-                                        label={shortEthAddress}
-                                        hasArrow
-                                        bg="brand.navy"
-                                        color="white"
-                                        borderRadius="md"
-                                    >
-                                        <Text
+                                    <Text
                                             className="player-username"
                                             variant={'seatText'}
                                             fontSize={{
@@ -1295,7 +1287,6 @@ const TakenSeatButton = ({
                                         >
                                             {player.username}
                                         </Text>
-                                    </Tooltip>
                                     {canSendSeatReaction && isSelf ? (
                                         <EmotePicker
                                             onSelectEmote={


### PR DESCRIPTION
Different wallet deposited than the one that created the table
Timeline:

22:59:24 — Table created with ownerAddress=0xC6812F8f12AeA1211fEb97225b9b27daBf2b6032
22:59:26 — WS connected with same address 0xC6812F8f12AeA1211fEb97225b9b27daBf2b6032 — correctly identified as owner
22:59:44 — Deposit event arrives from 0x70d1bea2248da64c10ce3b2045c9602982231992 — a completely different wallet
The owner address is 0xC681...6032 but the deposit came from 0x70d1...1992. The backend correctly treated this as a non-owner deposit (because it isn't the owner wallet), created a pending player, and sent the seat request to the owner.

When you accepted it, the system did Address lookup MISS: 0x70d1bea... because no WS client was connected with that wallet. The player was queued but then rejected with wallet-authenticated connection required to join crypto table.

This confirms the diagnosis exactly — you deposited from a different wallet than the one you created the table with. The lastAuthenticatedAddress check in TakeSeatModal would prevent this by blocking the deposit if the active thirdweb wallet doesn't match the JWT wallet.





**Now why does the thirdweb wallet does not match the JWT one? That is a good question... But this is just a safe-guard for it and it should be checked if it can be not triggered at all.**