### PR TITLE
feat: show spectator count in public games lobby

### DIFF
--- a/app/components/NavBar/Chat/ChatBox.tsx
+++ b/app/components/NavBar/Chat/ChatBox.tsx
@@ -21,7 +21,7 @@ import {
 } from 'react';
 import { AppContext } from '@/app/contexts/AppStoreProvider';
 import { SocketContext } from '@/app/contexts/WebSocketProvider';
-import { sendMessage } from '@/app/hooks/server_actions';
+import { sendMessage, getTableSpectatorCount } from '@/app/hooks/server_actions';
 import { IoClose } from 'react-icons/io5';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import { useEmotesData } from '@/app/hooks/useEmotesData';
@@ -60,6 +60,7 @@ const Chatbox = ({
     const [message, setMessage] = useState<string>('');
     const { appState, dispatch } = useContext(AppContext);
     const { username, clientID } = appState;
+    const [spectatorCount, setSpectatorCount] = useState<number>(0);
     const inputRef = useRef<HTMLInputElement | null>(null);
     const virtuosoRef = useRef<VirtuosoHandle | null>(null);
     const {
@@ -103,6 +104,21 @@ const Chatbox = ({
     useEffect(() => {
         ensureLoaded();
     }, [ensureLoaded]);
+
+    useEffect(() => {
+        const tableName = appState.table;
+        if (!tableName) return;
+
+        const fetch = () => {
+            getTableSpectatorCount(tableName)
+                .then(setSpectatorCount)
+                .catch(() => {});
+        };
+
+        fetch();
+        const interval = setInterval(fetch, 60_000);
+        return () => clearInterval(interval);
+    }, [appState.table]);
 
     // Auto-scroll to bottom when chat opens
     useEffect(() => {
@@ -246,14 +262,24 @@ const Chatbox = ({
                 top={0}
                 zIndex={10}
             >
-                <Text
-                    fontSize="xl"
-                    fontWeight="bold"
-                    color="text.secondary"
-                    fontFamily="heading"
-                >
-                    Chat
-                </Text>
+                <Flex align="center" gap={2}>
+                    <Text
+                        fontSize="xl"
+                        fontWeight="bold"
+                        color="text.secondary"
+                        fontFamily="heading"
+                    >
+                        Chat
+                    </Text>
+                    {spectatorCount > 0 && (
+                        <Flex align="center" gap={1}>
+                            <Icon as={FiEye} boxSize={3.5} color="text.secondary" opacity={0.7} />
+                            <Text fontSize="sm" color="text.secondary" opacity={0.7}>
+                                {spectatorCount}
+                            </Text>
+                        </Flex>
+                    )}
+                </Flex>
                 <Flex align="center" gap={2}>
                     <Tooltip
                         label={

--- a/app/hooks/server_actions.ts
+++ b/app/hooks/server_actions.ts
@@ -538,6 +538,20 @@ export async function getPublicGames() {
     }
 }
 
+export async function getTableSpectatorCount(tableName: string): Promise<number> {
+    isBackendUrlValid();
+
+    const response = await fetch(
+        `${backendUrl}/api/tables/${encodeURIComponent(tableName)}/spectators`,
+        { method: 'GET' }
+    );
+    if (!response.ok) {
+        throw new Error(`Spectator count fetch failed: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return data.spectator_count ?? 0;
+}
+
 export async function fetchTableEvents(
     tableName: string,
     limit: number = 50,

--- a/app/public-games/page.tsx
+++ b/app/public-games/page.tsx
@@ -229,17 +229,19 @@ const PublicGameRow = ({ game }: { game: PublicGame }) => {
                     display={{ base: 'block', md: 'none' }}
                     flexShrink={0}
                 />
-                <VStack align="start" spacing={0} minW={0}>
-                    <HStack spacing={1.5} flexWrap="wrap" align="center">
-                        <Text
-                            fontSize={{ base: 'sm', md: 'lg' }}
-                            fontWeight="bold"
-                            color="text.primary"
-                            fontFamily="monospace"
-                            noOfLines={1}
-                        >
-                            {game.name}
-                        </Text>
+                <VStack align="start" spacing={0.5} minW={0}>
+                    <Text
+                        fontSize={{ base: 'sm', md: 'lg' }}
+                        fontWeight="bold"
+                        color="text.primary"
+                        fontFamily="monospace"
+                        noOfLines={1}
+                        w="full"
+                        isTruncated
+                    >
+                        {game.name}
+                    </Text>
+                    <HStack spacing={1.5} align="center">
                         <Badge
                             bg={statusStyle.badgeBg}
                             color={statusStyle.badgeColor}


### PR DESCRIPTION
Add spectator count to /public-games + chat container.

Have a backend redis cache with 60 seconds TTL for the spectator count of a game.
Fix issues with crypto table names too long for mobile devices in public-games page