### PR TITLE
feat: TakeSeatModal redesign — hero input, BB presets, dark mode cont…

### DIFF
--- a/app/components/TakeSeat/BuyInPresets.tsx
+++ b/app/components/TakeSeat/BuyInPresets.tsx
@@ -1,0 +1,116 @@
+'use client';
+import React, { useMemo } from 'react';
+import { HStack, Text, VStack, Box } from '@chakra-ui/react';
+import { buildBuyInPresets, BuyInPreset } from '@/app/lib/takeSeat/presets';
+
+interface BuyInPresetsProps {
+    bb: number;
+    maxBuyIn: number;
+    walletBalanceChips: number | null;
+    isCrypto: boolean;
+    selectedChips: number | null;
+    onSelect: (chips: number) => void;
+    disabled?: boolean;
+}
+
+const PresetPill: React.FC<{
+    preset: BuyInPreset;
+    selected: boolean;
+    onClick: () => void;
+    disabled: boolean;
+}> = ({ preset, selected, onClick, disabled }) => {
+    const isDisabled = disabled || preset.disabled;
+    const labelColor = selected
+        ? 'white'
+        : isDisabled
+          ? 'text.muted'
+          : 'text.secondary';
+    const sublabelColor = selected ? 'whiteAlpha.800' : 'text.muted';
+    return (
+        <Box
+            as="button"
+            type="button"
+            onClick={onClick}
+            disabled={isDisabled}
+            flex="1"
+            minW={0}
+            px={2}
+            py={2}
+            borderRadius="xl"
+            bg={selected ? 'brand.navy' : 'card.lightGray'}
+            border="1.5px solid"
+            borderColor={selected ? 'brand.navy' : 'transparent'}
+            cursor={isDisabled ? 'not-allowed' : 'pointer'}
+            opacity={isDisabled ? 0.45 : 1}
+            transition="all 0.15s ease"
+            _hover={
+                !isDisabled && !selected
+                    ? {
+                          bg: 'card.white',
+                          borderColor: 'brand.navy',
+                          transform: 'translateY(-1px)',
+                      }
+                    : {}
+            }
+            _active={!isDisabled ? { transform: 'translateY(0)' } : {}}
+        >
+            <VStack spacing={0}>
+                <Text
+                    fontSize="sm"
+                    fontWeight="bold"
+                    letterSpacing="-0.01em"
+                    noOfLines={1}
+                    color={labelColor}
+                >
+                    {preset.label}
+                </Text>
+                {preset.sublabel && (
+                    <Text
+                        fontSize="2xs"
+                        fontWeight="bold"
+                        noOfLines={1}
+                        color={sublabelColor}
+                        textTransform="uppercase"
+                        letterSpacing="0.04em"
+                    >
+                        {preset.sublabel}
+                    </Text>
+                )}
+            </VStack>
+        </Box>
+    );
+};
+
+const BuyInPresets: React.FC<BuyInPresetsProps> = ({
+    bb,
+    maxBuyIn,
+    walletBalanceChips,
+    isCrypto,
+    selectedChips,
+    onSelect,
+    disabled = false,
+}) => {
+    const presets = useMemo(
+        () =>
+            buildBuyInPresets({ bb, maxBuyIn, walletBalanceChips, isCrypto }),
+        [bb, maxBuyIn, walletBalanceChips, isCrypto]
+    );
+
+    if (presets.length === 0) return null;
+
+    return (
+        <HStack w="100%" spacing={2}>
+            {presets.map((preset) => (
+                <PresetPill
+                    key={preset.key}
+                    preset={preset}
+                    selected={selectedChips === preset.chips && preset.chips > 0}
+                    onClick={() => onSelect(preset.chips)}
+                    disabled={disabled}
+                />
+            ))}
+        </HStack>
+    );
+};
+
+export default BuyInPresets;

--- a/app/components/TakeSeat/ChipStackVisualizer.tsx
+++ b/app/components/TakeSeat/ChipStackVisualizer.tsx
@@ -1,0 +1,133 @@
+'use client';
+import React, { useMemo } from 'react';
+import { Box, Flex, HStack, Text, VStack } from '@chakra-ui/react';
+import { keyframes } from '@emotion/react';
+import { breakdownChips, ChipColumn } from '@/app/lib/takeSeat/chipBreakdown';
+
+interface ChipStackVisualizerProps {
+    chips: number;
+    bb: number;
+    isInsufficient?: boolean;
+    orientation?: 'vertical' | 'horizontal';
+}
+
+const CHIP_FILL: Record<ChipColumn['color'], string> = {
+    white: 'white',
+    red: '#D84A4A',
+    green: 'brand.green',
+    black: 'brand.darkNavy',
+    purple: '#7C5BD1',
+};
+
+const chipIn = keyframes`
+    from { transform: scaleX(0.55) translateY(-4px); opacity: 0; }
+    to   { transform: scaleX(1) translateY(0); opacity: 1; }
+`;
+
+const ChipDisc: React.FC<{
+    color: ChipColumn['color'];
+    stripe: string;
+    index: number;
+}> = ({ color, stripe, index }) => (
+    <Box
+        w="38px"
+        h="8px"
+        borderRadius="full"
+        bg={CHIP_FILL[color]}
+        border="1.5px dashed"
+        borderColor={stripe}
+        boxShadow="0 1px 1px rgba(0,0,0,0.25)"
+        mt="-2.5px"
+        _first={{ mt: 0 }}
+        animation={`${chipIn} 0.2s ease-out both`}
+        style={{ animationDelay: `${index * 15}ms` }}
+    />
+);
+
+const EmptyStack = () => (
+    <Flex
+        minH="64px"
+        align="center"
+        justify="center"
+        w="100%"
+        opacity={0.3}
+    >
+        <VStack spacing={0} align="center">
+            {[0, 1, 2].map((i) => (
+                <Box
+                    key={i}
+                    w="38px"
+                    h="8px"
+                    borderRadius="full"
+                    bg="transparent"
+                    border="1.5px dashed"
+                    borderColor="text.muted"
+                    mt={i === 0 ? 0 : '-2.5px'}
+                />
+            ))}
+        </VStack>
+    </Flex>
+);
+
+const ChipStackVisualizer: React.FC<ChipStackVisualizerProps> = ({
+    chips,
+    bb,
+    isInsufficient = false,
+    orientation = 'horizontal',
+}) => {
+    const columns = useMemo(() => breakdownChips(chips, bb), [chips, bb]);
+
+    if (columns.length === 0) {
+        return <EmptyStack />;
+    }
+
+    return (
+        <Box
+            w="100%"
+            filter={isInsufficient ? 'grayscale(1)' : 'none'}
+            opacity={isInsufficient ? 0.55 : 1}
+            transition="filter 0.2s ease, opacity 0.2s ease"
+        >
+            <HStack
+                spacing={orientation === 'horizontal' ? 2.5 : 3}
+                align="flex-end"
+                justify="center"
+                minH="64px"
+            >
+                {columns.map((col) => (
+                    <VStack key={col.denom} spacing={0} align="center">
+                        {col.count > col.visible && (
+                            <Text
+                                fontSize="9px"
+                                fontWeight="bold"
+                                color="text.muted"
+                                mb="2px"
+                                letterSpacing="0.04em"
+                            >
+                                ×{col.count.toLocaleString('en-US')}
+                            </Text>
+                        )}
+                        <VStack
+                            spacing={0}
+                            align="center"
+                            sx={{ transformOrigin: 'bottom center' }}
+                        >
+                            {Array.from({ length: col.visible })
+                                .map((_, i) => col.visible - 1 - i)
+                                .map((i) => (
+                                    <ChipDisc
+                                        key={`${col.denom}-${i}-${col.count}`}
+                                        color={col.color}
+                                        stripe={col.stripe}
+                                        index={i}
+                                    />
+                                ))}
+                        </VStack>
+                    </VStack>
+                ))}
+            </HStack>
+        </Box>
+    );
+};
+
+export default ChipStackVisualizer;

--- a/app/components/TakeSeat/StakesChip.tsx
+++ b/app/components/TakeSeat/StakesChip.tsx
@@ -1,0 +1,126 @@
+'use client';
+import React from 'react';
+import { HStack, Image, Text, Box } from '@chakra-ui/react';
+
+interface StakesChipProps {
+    sb: number;
+    bb: number;
+    seatId?: number;
+    isCrypto: boolean;
+    chain?: string;
+}
+
+const CHIPS_PER_USDC = 100;
+
+const getChainLogo = (chain?: string): string | null => {
+    if (!chain) return null;
+    const c = chain.toLowerCase();
+    if (c === 'base' || c === 'base sepolia' || c === 'base-sepolia')
+        return '/networkLogos/base-logo.png';
+    if (c === 'arbitrum') return '/networkLogos/arbitrum-logo.png';
+    if (c === 'optimism') return '/networkLogos/optimism-logo.png';
+    if (c === 'solana') return '/networkLogos/solana-logo.png';
+    return null;
+};
+
+const formatBlind = (chips: number, isCrypto: boolean): string => {
+    if (isCrypto) {
+        const dollars = chips / CHIPS_PER_USDC;
+        if (dollars >= 100) return '$' + Math.round(dollars).toLocaleString('en-US');
+        if (dollars >= 10) return '$' + dollars.toFixed(0);
+        return '$' + dollars.toFixed(2);
+    }
+    return chips.toLocaleString('en-US');
+};
+
+const Dot = () => (
+    <Text
+        as="span"
+        fontSize="xs"
+        color="text.muted"
+        opacity={0.5}
+        mx={1.5}
+        userSelect="none"
+    >
+        ·
+    </Text>
+);
+
+const StakesChip: React.FC<StakesChipProps> = ({
+    sb,
+    bb,
+    seatId,
+    isCrypto,
+    chain,
+}) => {
+    if (!sb || !bb) return null;
+
+    const chainLogo = getChainLogo(chain);
+    const stakesLabel = `NLH ${formatBlind(sb, isCrypto)}/${formatBlind(bb, isCrypto)}`;
+
+    return (
+        <HStack
+            spacing={0}
+            justify="center"
+            align="center"
+            flexWrap="wrap"
+            rowGap={0}
+        >
+            <Text
+                fontSize="xs"
+                fontWeight="bold"
+                color="text.secondary"
+                letterSpacing="0.02em"
+                textTransform="uppercase"
+                whiteSpace="nowrap"
+            >
+                {stakesLabel}
+            </Text>
+            {seatId !== undefined && (
+                <>
+                    <Dot />
+                    <Text
+                        fontSize="xs"
+                        fontWeight="bold"
+                        color="text.secondary"
+                        letterSpacing="0.02em"
+                        textTransform="uppercase"
+                        whiteSpace="nowrap"
+                    >
+                        Seat {seatId}
+                    </Text>
+                </>
+            )}
+            {isCrypto && chain && (
+                <>
+                    <Dot />
+                    <HStack spacing={1}>
+                        {chainLogo && (
+                            <Box boxSize="12px" flexShrink={0}>
+                                <Image
+                                    src={chainLogo}
+                                    alt={chain}
+                                    w="100%"
+                                    h="100%"
+                                    objectFit="contain"
+                                />
+                            </Box>
+                        )}
+                        <Text
+                            fontSize="xs"
+                            fontWeight="bold"
+                            color="text.secondary"
+                            letterSpacing="0.02em"
+                            textTransform="uppercase"
+                            whiteSpace="nowrap"
+                        >
+                            {chain}
+                        </Text>
+                    </HStack>
+                </>
+            )}
+        </HStack>
+    );
+};
+
+export default StakesChip;

--- a/app/components/TakeSeatModal.stories.tsx
+++ b/app/components/TakeSeatModal.stories.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import {
     Box,
     Button,
-    Center,
+    Collapse,
     Flex,
     FormControl,
     HStack,
@@ -15,24 +15,20 @@ import {
     Input,
     Link,
     Text,
-    Tooltip,
     VStack,
+    useDisclosure,
 } from '@chakra-ui/react';
 import { keyframes } from '@emotion/react';
-import { FaInfoCircle } from 'react-icons/fa';
+import { FaInfoCircle, FaChevronDown } from 'react-icons/fa';
 import { FaXTwitter } from 'react-icons/fa6';
+import BuyInPresets from './TakeSeat/BuyInPresets';
+import StakesChip from './TakeSeat/StakesChip';
 
 /**
- * Visual-only preview of TakeSeatModal.
- * Renders the modal body directly (no Chakra Modal/overlay, no hooks)
- * so every visual state is inspectable in Storybook without providers.
+ * Visual-only preview of TakeSeatModal (direction C redesign).
+ * Mirrors the modal body layout without Chakra Modal/overlay or providers,
+ * so every visual state is inspectable in Storybook.
  */
-
-const gradientShift = keyframes`
-    0% { background-position: 0% 50%; }
-    50% { background-position: 100% 50%; }
-    100% { background-position: 0% 50%; }
-`;
 
 const float = keyframes`
     0%, 100% { transform: translateY(0px); }
@@ -51,7 +47,19 @@ interface TakeSeatPreviewProps {
     showWithdrawFirst?: boolean;
     existingChipBalance?: string | null;
     isBalanceInsufficient?: boolean;
+    sb: number;
+    bb: number;
+    maxBuyIn: number;
+    seatId?: number;
+    chain?: string;
+    defaultBuyInChips?: number;
 }
+
+const formatUsdc = (chips: number): string =>
+    (chips / CHIPS_PER_USDC).toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    });
 
 const TakeSeatPreview: React.FC<TakeSeatPreviewProps> = ({
     isCryptoGame,
@@ -63,209 +71,281 @@ const TakeSeatPreview: React.FC<TakeSeatPreviewProps> = ({
     showWithdrawFirst = false,
     existingChipBalance = null,
     isBalanceInsufficient = false,
+    sb,
+    bb,
+    maxBuyIn,
+    seatId,
+    chain,
+    defaultBuyInChips,
 }) => {
     const [inputUnit, setInputUnit] = useState<'chips' | 'usdc'>(
         isCryptoGame ? 'usdc' : 'chips'
     );
-    const [buyInInput, setBuyInInput] = useState('');
+    const initialChips = defaultBuyInChips ?? maxBuyIn;
+    const [buyIn, setBuyIn] = useState<number>(initialChips);
+    const [buyInInput, setBuyInInput] = useState(
+        isCryptoGame
+            ? (initialChips / CHIPS_PER_USDC).toFixed(2)
+            : initialChips.toString()
+    );
+    const finePrint = useDisclosure({ defaultIsOpen: false });
+
+    const walletBalanceChips = useMemo(() => {
+        if (!isCryptoGame || !usdcBalance) return null;
+        return Math.floor(Number(usdcBalance) * CHIPS_PER_USDC);
+    }, [isCryptoGame, usdcBalance]);
 
     const truncatedAddress = walletAddress
         ? `${walletAddress.substring(0, 6)}...${walletAddress.substring(walletAddress.length - 4)}`
         : null;
 
-    const isJoinDisabled = !buyInInput || showWithdrawFirst;
+    const formattedChips = buyIn.toLocaleString('en-US');
+    const formattedUsdcEst = formatUsdc(buyIn);
+
+    const handleBuyInChange = (value: string) => {
+        if (isCryptoGame) {
+            if (inputUnit === 'usdc') {
+                if (!/^\d*(\.\d{0,2})?$/.test(value)) return;
+                setBuyInInput(value);
+                setBuyIn(value === '' ? 0 : Math.round(Number(value) * CHIPS_PER_USDC));
+                return;
+            }
+        }
+        if (!/^\d*$/.test(value)) return;
+        setBuyInInput(value);
+        setBuyIn(value === '' ? 0 : Number(value));
+    };
+
+    const handleUnitChange = (unit: 'chips' | 'usdc') => {
+        if (unit === inputUnit) return;
+        setInputUnit(unit);
+        if (unit === 'usdc') {
+            setBuyInInput(formatUsdc(buyIn));
+        } else {
+            setBuyInInput(Math.round(buyIn).toString());
+        }
+    };
+
+    const applyBuyInChips = (chips: number) => {
+        setBuyIn(chips);
+        setBuyInInput(
+            isCryptoGame && inputUnit === 'usdc'
+                ? formatUsdc(chips)
+                : Math.round(chips).toString()
+        );
+    };
+
+    const isJoinDisabled = buyIn <= 0;
 
     return (
         <Box
-            borderRadius="32px"
-            maxWidth="420px"
-            minWidth="320px"
+            borderRadius={{ base: '24px', sm: '28px' }}
+            maxWidth={{ base: 'calc(100vw - 24px)', sm: '420px' }}
+            mx="auto"
             boxShadow="0 20px 60px rgba(0, 0, 0, 0.25), 0 0 0 1px rgba(0, 0, 0, 0.05)"
             overflow="hidden"
             position="relative"
+            bg="card.white"
             border="1px solid"
-            borderColor="card.white"
-            mx="auto"
+            borderColor="border.lightGray"
+            minWidth="320px"
         >
-            {/* Animated gradient border */}
+            {/* Chair easter egg — bottom-right, quiet */}
             <Box
                 position="absolute"
-                top={0}
-                left={0}
-                right={0}
-                bottom={0}
-                borderRadius="32px"
-                padding="3px"
-                bgGradient="linear(to-r, brand.pink, brand.green, brand.yellow, brand.pink)"
-                backgroundSize="200% 200%"
-                animation={`${gradientShift} 8s ease infinite`}
-                pointerEvents="none"
-                zIndex={0}
+                bottom={3}
+                right={3}
+                fontSize="sm"
+                opacity={0.35}
+                animation={`${float} 5s ease-in-out infinite`}
+                cursor="pointer"
+                zIndex={2}
+                _hover={{ opacity: 1 }}
+                transition="opacity 0.2s ease"
             >
-                <Box
-                    width="100%"
-                    height="100%"
-                    bg="card.white"
-                    borderRadius="29px"
-                />
+                🪑
             </Box>
 
-            {/* Content */}
-            <Box position="relative" zIndex={1} bg="card.white">
-                {/* Chair easter egg */}
-                <Tooltip
-                    label='"All you need is a chip and a chair." — Jack Straus'
-                    fontSize="xs"
-                    placement="bottom"
-                    bg="brand.navy"
-                    color="white"
-                    borderRadius="lg"
-                    px={3}
-                    py={1.5}
-                >
-                    <Box
-                        position="absolute"
-                        top={3}
-                        left={4}
-                        fontSize="xl"
-                        opacity={0.7}
-                        animation={`${float} 5s ease-in-out infinite`}
-                        cursor="pointer"
-                        zIndex={2}
-                    >
-                        🪑
+            {/* Close placeholder */}
+            <Box
+                position="absolute"
+                top={3}
+                right={3}
+                w="28px"
+                h="28px"
+                borderRadius="full"
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                cursor="pointer"
+                color="text.secondary"
+                _hover={{ bg: 'card.lightGray' }}
+                fontSize="md"
+                zIndex={2}
+            >
+                ✕
+            </Box>
+
+            {showWithdrawFirst ? (
+                <>
+                    <Box textAlign="center" pt={10} pb={2} px={6}>
+                        <VStack spacing={2}>
+                            <Heading
+                                as="h2"
+                                fontSize="xl"
+                                fontWeight="bold"
+                                color="text.secondary"
+                                letterSpacing="-0.02em"
+                            >
+                                Chips still on this table
+                            </Heading>
+                            <StakesChip
+                                sb={sb}
+                                bb={bb}
+                                seatId={seatId}
+                                isCrypto={isCryptoGame}
+                                chain={chain}
+                            />
+                        </VStack>
                     </Box>
-                </Tooltip>
-
-                {/* Close button placeholder */}
-                <Box
-                    position="absolute"
-                    top={3}
-                    right={3}
-                    w="28px"
-                    h="28px"
-                    borderRadius="full"
-                    display="flex"
-                    alignItems="center"
-                    justifyContent="center"
-                    cursor="pointer"
-                    color="text.secondary"
-                    _hover={{ bg: 'card.lightGray' }}
-                    fontSize="md"
-                    zIndex={2}
-                >
-                    ✕
-                </Box>
-
-                {/* Header */}
-                <Box textAlign="center" pt={10} pb={2} px={8}>
-                    <VStack spacing={1}>
-                        <Heading
-                            as="h2"
-                            fontSize="xl"
-                            fontWeight="bold"
-                            color="text.secondary"
-                            letterSpacing="-0.02em"
-                        >
-                            Take your seat
-                        </Heading>
-                        <Text
-                            fontSize="xs"
-                            color="text.muted"
-                            fontWeight="medium"
-                            textAlign="center"
-                        >
-                            {isCryptoGame
-                                ? 'Deposit USDC to join the table'
-                                : 'Join the table and start playing'}
-                        </Text>
-                    </VStack>
-                </Box>
-
-                {/* Body */}
-                <Box px={7} pb={3} pt={1}>
-                    <Center>
-                        <VStack w="100%" spacing={4}>
-                            {/* Withdraw-first warning */}
-                            {showWithdrawFirst && (
-                                <VStack
-                                    w="100%"
-                                    spacing={3}
-                                    bg="orange.50"
-                                    borderRadius="xl"
-                                    px={4}
-                                    py={4}
-                                    border="1px solid"
-                                    borderColor="orange.200"
-                                >
-                                    <HStack spacing={2} alignItems="flex-start" w="100%">
-                                        <Icon as={FaInfoCircle} boxSize={4} color="orange.500" mt={0.5} flexShrink={0} />
-                                        <VStack spacing={1} alignItems="flex-start">
-                                            <Text fontSize="sm" fontWeight="semibold" color="orange.700">
-                                                Chips already in contract
-                                            </Text>
-                                            <Text fontSize="xs" color="orange.600" lineHeight="short">
-                                                You have {existingChipBalance || '5,000'} chips sitting in this contract
-                                                from a previous deposit. Withdraw them first, then deposit a new amount to join.
-                                            </Text>
-                                        </VStack>
-                                    </HStack>
+                    <Box px={{ base: 5, sm: 7 }} pb={2} pt={2}>
+                        <VStack spacing={4} w="100%">
+                            <Box
+                                w="100%"
+                                bg="card.lightGray"
+                                borderRadius="xl"
+                                px={5}
+                                py={5}
+                                textAlign="center"
+                            >
+                                <VStack spacing={2}>
+                                    <Text
+                                        fontSize="3xl"
+                                        fontWeight="bold"
+                                        color="text.secondary"
+                                        letterSpacing="-0.02em"
+                                        lineHeight={1}
+                                    >
+                                        {existingChipBalance ?? '—'}
+                                    </Text>
+                                    <Text
+                                        fontSize="xs"
+                                        color="text.muted"
+                                        fontWeight="medium"
+                                        textTransform="uppercase"
+                                        letterSpacing="0.05em"
+                                    >
+                                        chips in contract
+                                    </Text>
                                 </VStack>
-                            )}
+                            </Box>
+                            <Text
+                                fontSize="sm"
+                                color="text.secondary"
+                                textAlign="center"
+                                lineHeight="short"
+                                px={2}
+                            >
+                                Withdraw these to your wallet first, then you can
+                                deposit a new amount and take your seat.
+                            </Text>
+                        </VStack>
+                    </Box>
+                    <Box px={{ base: 5, sm: 7 }} pb={7} pt={4}>
+                        <VStack w="100%" spacing={3}>
+                            <Button
+                                w="100%"
+                                h="52px"
+                                borderRadius="bigButton"
+                                bg="brand.navy"
+                                color="white"
+                                fontWeight="bold"
+                                fontSize="sm"
+                            >
+                                {truncatedAddress ?? 'Sign In'}
+                            </Button>
+                            <Button
+                                w="100%"
+                                h="52px"
+                                fontSize="md"
+                                fontWeight="bold"
+                                borderRadius="bigButton"
+                                bg="brand.pink"
+                                color="white"
+                            >
+                                Withdraw &amp; start fresh
+                            </Button>
+                        </VStack>
+                    </Box>
+                </>
+            ) : (
+                <>
+                    <Box textAlign="center" pt={10} pb={2} px={6}>
+                        <VStack spacing={1.5}>
+                            <Heading
+                                as="h2"
+                                fontSize="xl"
+                                fontWeight="bold"
+                                color="text.secondary"
+                                letterSpacing="-0.02em"
+                            >
+                                Take your seat
+                            </Heading>
+                            <StakesChip
+                                sb={sb}
+                                bb={bb}
+                                seatId={seatId}
+                                isCrypto={isCryptoGame}
+                                chain={chain}
+                            />
+                        </VStack>
+                    </Box>
 
-                            {/* X-linked identity banner */}
-                            {!showWithdrawFirst && xUsername && (
+                    <Box px={{ base: 5, sm: 7 }} pb={2} pt={2}>
+                        <VStack w="100%" spacing={4}>
+                            {/* Identity */}
+                            {xUsername ? (
                                 <HStack
-                                    spacing={3}
-                                    py={2}
-                                    px={3}
+                                    spacing={2}
+                                    py={1}
                                     w="100%"
-                                    bg="card.lightGray"
-                                    borderRadius="xl"
+                                    justify="center"
                                 >
                                     {xProfileImageUrl ? (
                                         <Image
                                             src={xProfileImageUrl}
                                             alt="X avatar"
-                                            boxSize="34px"
+                                            boxSize="22px"
                                             borderRadius="full"
                                             objectFit="cover"
                                             flexShrink={0}
                                         />
                                     ) : (
                                         <Flex
-                                            boxSize="34px"
+                                            boxSize="22px"
                                             borderRadius="full"
                                             bg="black"
                                             alignItems="center"
                                             justifyContent="center"
                                             flexShrink={0}
                                         >
-                                            <Icon as={FaXTwitter} boxSize={3.5} color="white" />
+                                            <Icon
+                                                as={FaXTwitter}
+                                                boxSize={2.5}
+                                                color="white"
+                                            />
                                         </Flex>
                                     )}
-                                    <HStack spacing={1.5} flex={1} minW={0}>
-                                        <Icon
-                                            as={FaXTwitter}
-                                            boxSize="11px"
-                                            color="text.primary"
-                                            opacity={0.5}
-                                            flexShrink={0}
-                                        />
-                                        <Text
-                                            fontSize="sm"
-                                            fontWeight="bold"
-                                            color="text.secondary"
-                                            noOfLines={1}
-                                        >
-                                            @{xUsername}
-                                        </Text>
-                                    </HStack>
+                                    <Text
+                                        fontSize="sm"
+                                        fontWeight="semibold"
+                                        color="text.secondary"
+                                        noOfLines={1}
+                                    >
+                                        @{xUsername}
+                                    </Text>
                                 </HStack>
-                            )}
-
-                            {/* Connect X button (no X linked) */}
-                            {!showWithdrawFirst && !xUsername && (
+                            ) : (
                                 <VStack spacing={3} w="100%">
                                     <HStack
                                         as="button"
@@ -276,21 +356,29 @@ const TakeSeatPreview: React.FC<TakeSeatPreviewProps> = ({
                                         cursor="pointer"
                                         bg="transparent"
                                         border="none"
-                                        opacity={0.55}
+                                        opacity={0.6}
                                         _hover={{ opacity: 1 }}
                                         transition="opacity 0.15s ease"
                                     >
                                         <Icon as={FaXTwitter} boxSize={3.5} color="text.primary" />
-                                        <Text fontSize="sm" fontWeight="medium" color="text.secondary">
+                                        <Text
+                                            fontSize="sm"
+                                            fontWeight="medium"
+                                            color="text.secondary"
+                                        >
                                             Sign in with X
                                         </Text>
                                     </HStack>
-
                                     {!isCryptoGame && (
                                         <>
                                             <HStack w="100%" spacing={3} align="center">
                                                 <Box flex={1} h="1px" bg="border.lightGray" />
-                                                <Text fontSize="xs" color="text.secondary" fontWeight="medium" opacity={0.6}>
+                                                <Text
+                                                    fontSize="xs"
+                                                    color="text.secondary"
+                                                    fontWeight="medium"
+                                                    opacity={0.6}
+                                                >
                                                     or
                                                 </Text>
                                                 <Box flex={1} h="1px" bg="border.lightGray" />
@@ -307,106 +395,190 @@ const TakeSeatPreview: React.FC<TakeSeatPreviewProps> = ({
                                 </VStack>
                             )}
 
-                            {/* Buy-in input */}
-                            {!showWithdrawFirst && (
-                                <FormControl>
-                                    <Flex alignItems="center" justifyContent="space-between" mb={1.5}>
-                                        <Text
-                                            fontSize="xs"
-                                            fontWeight="semibold"
-                                            color="text.secondary"
-                                            textTransform="none"
-                                        >
-                                            Buy-in amount
-                                        </Text>
-                                        {isCryptoGame && (
-                                            <Box position="relative" width="140px" height="28px">
-                                                <Box position="absolute" inset={0} bg="card.lightGray" borderRadius="full" />
-                                                <Box
-                                                    position="absolute"
-                                                    top="3px"
-                                                    left={inputUnit === 'chips' ? '3px' : 'calc(50% + 3px)'}
-                                                    width="calc(50% - 6px)"
-                                                    height="22px"
-                                                    bg="card.white"
-                                                    borderRadius="full"
-                                                    boxShadow="sm"
-                                                    transition="left 0.25s cubic-bezier(0.4, 0, 0.2, 1)"
-                                                />
-                                                <Flex position="relative" zIndex={1} alignItems="center" justifyContent="space-between" height="full">
-                                                    <Box
-                                                        as="button"
-                                                        type="button"
-                                                        flex="1"
-                                                        height="full"
-                                                        display="flex"
-                                                        alignItems="center"
-                                                        justifyContent="center"
-                                                        cursor="pointer"
-                                                        onClick={() => setInputUnit('chips')}
-                                                        background="transparent"
-                                                    >
-                                                        <Text fontSize="xs" fontWeight="semibold" color={inputUnit === 'chips' ? 'text.secondary' : 'text.muted'} whiteSpace="nowrap">
-                                                            Chips
-                                                        </Text>
-                                                    </Box>
-                                                    <Box
-                                                        as="button"
-                                                        type="button"
-                                                        flex="1"
-                                                        height="full"
-                                                        display="flex"
-                                                        alignItems="center"
-                                                        justifyContent="center"
-                                                        cursor="pointer"
-                                                        onClick={() => setInputUnit('usdc')}
-                                                        background="transparent"
-                                                    >
-                                                        <Text fontSize="xs" fontWeight="semibold" color={inputUnit === 'usdc' ? 'text.secondary' : 'text.muted'} whiteSpace="nowrap">
-                                                            USDC
-                                                        </Text>
-                                                    </Box>
-                                                </Flex>
-                                            </Box>
-                                        )}
-                                    </Flex>
-                                    <Box position="relative">
-                                        <Input
-                                            placeholder={isCryptoGame ? (inputUnit === 'usdc' ? 'Enter USDC' : 'Enter chips') : 'Buy-in amount'}
-                                            type="number"
-                                            variant="takeSeatModal"
-                                            value={buyInInput}
-                                            onChange={(e) => setBuyInInput(e.target.value)}
-                                            pr="70px"
-                                        />
-                                        <Text
-                                            position="absolute"
-                                            right="16px"
-                                            top="50%"
-                                            transform="translateY(-50%)"
-                                            fontSize="xs"
-                                            color="text.muted"
-                                            fontWeight="semibold"
-                                            letterSpacing="0.02em"
-                                            pointerEvents="none"
-                                            textTransform="uppercase"
-                                        >
-                                            {isCryptoGame ? inputUnit : 'chips'}
-                                        </Text>
-                                    </Box>
+                            {/* Buy-in: hero input */}
+                            <FormControl>
+                                <Flex
+                                    alignItems="center"
+                                    justifyContent="space-between"
+                                    mb={2}
+                                >
+                                    <Text
+                                        fontSize="2xs"
+                                        color="text.muted"
+                                        fontWeight="bold"
+                                        textTransform="uppercase"
+                                        letterSpacing="0.06em"
+                                    >
+                                        Buy-in
+                                    </Text>
                                     {isCryptoGame && (
-                                        <Flex mt={2} alignItems="center" justifyContent="space-between" gap={2} fontSize="xs" color="text.secondary" fontWeight="medium" lineHeight="short">
-                                            <Flex alignItems="center" gap={1}>
-                                                <Text as="span" color="text.secondary">{CHIPS_PER_USDC} chips = 1 USDC</Text>
-                                                <Image src="/usdc-logo.png" alt="USDC" boxSize="14px" loading="lazy" flexShrink={0} />
+                                        <Box position="relative" width="120px" height="26px">
+                                            <Box
+                                                position="absolute"
+                                                inset={0}
+                                                bg="card.lightGray"
+                                                borderRadius="full"
+                                            />
+                                            <Box
+                                                position="absolute"
+                                                top="3px"
+                                                left={
+                                                    inputUnit === 'chips'
+                                                        ? '3px'
+                                                        : 'calc(50% + 1px)'
+                                                }
+                                                width="calc(50% - 4px)"
+                                                height="20px"
+                                                bg="card.white"
+                                                borderRadius="full"
+                                                boxShadow="sm"
+                                                transition="left 0.22s cubic-bezier(0.4, 0, 0.2, 1)"
+                                            />
+                                            <Flex
+                                                position="relative"
+                                                zIndex={1}
+                                                alignItems="center"
+                                                justifyContent="space-between"
+                                                height="full"
+                                            >
+                                                {(['chips', 'usdc'] as const).map((unit) => (
+                                                    <Box
+                                                        as="button"
+                                                        type="button"
+                                                        key={unit}
+                                                        flex="1"
+                                                        height="full"
+                                                        display="flex"
+                                                        alignItems="center"
+                                                        justifyContent="center"
+                                                        cursor="pointer"
+                                                        onClick={() => handleUnitChange(unit)}
+                                                        background="transparent"
+                                                    >
+                                                        <Text
+                                                            fontSize="2xs"
+                                                            fontWeight="bold"
+                                                            letterSpacing="0.05em"
+                                                            textTransform="uppercase"
+                                                            color={
+                                                                inputUnit === unit
+                                                                    ? 'text.secondary'
+                                                                    : 'text.muted'
+                                                            }
+                                                        >
+                                                            {unit === 'usdc' ? 'USDC' : 'Chips'}
+                                                        </Text>
+                                                    </Box>
+                                                ))}
                                             </Flex>
-                                        </Flex>
+                                        </Box>
                                     )}
-                                </FormControl>
-                            )}
+                                </Flex>
+                                {/* Hero input — borderless, oversized, centered */}
+                                <Flex
+                                    align="baseline"
+                                    justify="center"
+                                    gap={2}
+                                    opacity={isBalanceInsufficient ? 0.5 : 1}
+                                    transition="opacity 0.2s ease"
+                                >
+                                    <Input
+                                        placeholder={
+                                            isCryptoGame
+                                                ? inputUnit === 'usdc'
+                                                    ? '0.00'
+                                                    : '0'
+                                                : '0'
+                                        }
+                                        type="text"
+                                        inputMode={
+                                            isCryptoGame && inputUnit === 'usdc'
+                                                ? 'decimal'
+                                                : 'numeric'
+                                        }
+                                        pattern={
+                                            isCryptoGame && inputUnit === 'usdc'
+                                                ? '[0-9]*\\.?[0-9]*'
+                                                : '[0-9]*'
+                                        }
+                                        autoComplete="off"
+                                        value={buyInInput}
+                                        onChange={(e) => handleBuyInChange(e.target.value)}
+                                        htmlSize={Math.max(
+                                            buyInInput.length || 4,
+                                            isCryptoGame && inputUnit === 'usdc' ? 4 : 1
+                                        )}
+                                        variant="unstyled"
+                                        textAlign="right"
+                                        fontSize="4xl"
+                                        fontWeight="bold"
+                                        letterSpacing="-0.03em"
+                                        color="text.secondary"
+                                        lineHeight={1}
+                                        height="auto"
+                                        width="auto"
+                                        minW={0}
+                                        flex="0 0 auto"
+                                    />
+                                    <Text
+                                        fontSize="md"
+                                        fontWeight="bold"
+                                        color="text.muted"
+                                        textTransform="uppercase"
+                                        letterSpacing="0.06em"
+                                    >
+                                        {isCryptoGame ? inputUnit : 'chips'}
+                                    </Text>
+                                </Flex>
+                                {isCryptoGame && (
+                                    <Text
+                                        mt={1.5}
+                                        textAlign="right"
+                                        fontSize="2xs"
+                                        color="text.muted"
+                                        fontWeight="bold"
+                                        textTransform="uppercase"
+                                        letterSpacing="0.06em"
+                                    >
+                                        ≈{' '}
+                                        {inputUnit === 'usdc'
+                                            ? `${formattedChips} chips`
+                                            : `$${formattedUsdcEst}`}
+                                    </Text>
+                                )}
+                            </FormControl>
 
-                            {/* USDC balance card (crypto only) */}
-                            {!showWithdrawFirst && isCryptoGame && isConnected && usdcBalance && (
+                            {/* Presets */}
+                            {bb > 0 && (
+                                <BuyInPresets
+                                    bb={bb}
+                                    maxBuyIn={maxBuyIn}
+                                    walletBalanceChips={walletBalanceChips}
+                                    isCrypto={isCryptoGame}
+                                    selectedChips={buyIn}
+                                    onSelect={applyBuyInChips}
+                                />
+                            )}
+                        </VStack>
+                    </Box>
+
+                    <Box px={{ base: 5, sm: 7 }} pb={6} pt={3}>
+                        <VStack w="100%" spacing={3}>
+                            {isCryptoGame && !isConnected && (
+                                <Button
+                                    w="100%"
+                                    h="52px"
+                                    borderRadius="bigButton"
+                                    bg="brand.navy"
+                                    _dark={{ bg: 'brand.lightGray', color: 'brand.darkNavy' }}
+                                    color="white"
+                                    fontSize="sm"
+                                    fontWeight="bold"
+                                >
+                                    Sign In
+                                </Button>
+                            )}
+                            {isCryptoGame && isConnected && truncatedAddress && (
                                 <Flex
                                     w="100%"
                                     bg="card.lightGray"
@@ -416,9 +588,19 @@ const TakeSeatPreview: React.FC<TakeSeatPreviewProps> = ({
                                     alignItems="center"
                                     gap={3}
                                 >
-                                    <Image src="/usdc-logo.png" alt="USDC" boxSize="32px" loading="lazy" flexShrink={0} />
-                                    <VStack spacing={0} alignItems="flex-start">
-                                        <Text fontSize="sm" fontWeight="semibold" color="text.secondary">
+                                    <Image
+                                        src="/usdc-logo.png"
+                                        alt="USDC"
+                                        boxSize="28px"
+                                        loading="lazy"
+                                        flexShrink={0}
+                                    />
+                                    <VStack spacing={0} alignItems="flex-start" flex={1}>
+                                        <Text
+                                            fontSize="sm"
+                                            fontWeight="semibold"
+                                            color="text.secondary"
+                                        >
                                             {truncatedAddress}
                                         </Text>
                                         <Text fontSize="xs" color="text.muted">
@@ -427,115 +609,177 @@ const TakeSeatPreview: React.FC<TakeSeatPreviewProps> = ({
                                     </VStack>
                                 </Flex>
                             )}
-                        </VStack>
-                    </Center>
-                </Box>
 
-                {/* Footer */}
-                <Box px={7} pb={7} pt={2}>
-                    <VStack w="100%" spacing={4}>
-                        {/* Wallet sign-in placeholder (crypto, not connected) */}
-                        {isCryptoGame && !isConnected && (
+                            {isCryptoGame && !isConnected && (
+                                <HStack
+                                    spacing={2}
+                                    alignItems="flex-start"
+                                    bg="rgba(54, 163, 123, 0.15)"
+                                    borderRadius="md"
+                                    px={3}
+                                    py={2}
+                                    width="100%"
+                                >
+                                    <Icon
+                                        as={FaInfoCircle}
+                                        boxSize={3.5}
+                                        mt={0.5}
+                                        color="brand.green"
+                                    />
+                                    <Text
+                                        fontSize="xs"
+                                        fontWeight="semibold"
+                                        color="brand.green"
+                                        textAlign="left"
+                                    >
+                                        Sign in with your wallet to join this crypto game.
+                                    </Text>
+                                </HStack>
+                            )}
+
+                            {isBalanceInsufficient && (
+                                <HStack
+                                    spacing={2}
+                                    alignItems="flex-start"
+                                    bg="red.50"
+                                    borderRadius="md"
+                                    px={3}
+                                    py={2}
+                                    width="100%"
+                                >
+                                    <Icon
+                                        as={FaInfoCircle}
+                                        boxSize={3.5}
+                                        mt={0.5}
+                                        color="red.700"
+                                    />
+                                    <Text
+                                        fontSize="xs"
+                                        fontWeight="semibold"
+                                        color="red.700"
+                                        textAlign="left"
+                                    >
+                                        Insufficient USDC balance
+                                        {usdcBalance ? ` (you have ${usdcBalance} USDC)` : ''}.
+                                    </Text>
+                                </HStack>
+                            )}
+
                             <Button
                                 w="100%"
-                                h="50px"
-                                fontSize="sm"
-                                fontWeight="bold"
+                                h="56px"
                                 borderRadius="bigButton"
-                                bg="brand.navy"
-                                _dark={{ bg: 'brand.lightGray', color: 'brand.darkNavy' }}
-                                color="white"
+                                bg={isJoinDisabled ? 'btn.lightGray' : 'brand.green'}
                                 border="none"
-                                _hover={{ transform: 'translateY(-1px)' }}
-                                transition="all 0.2s ease"
-                            >
-                                Sign In
-                            </Button>
-                        )}
-
-                        {/* Wallet hint (crypto, not connected) */}
-                        {isCryptoGame && !isConnected && (
-                            <HStack spacing={2} alignItems="flex-start" bg="rgba(54, 163, 123, 0.12)" color="green.700" borderRadius="md" px={3} py={2} fontSize="xs" fontWeight="medium" width="100%">
-                                <Icon as={FaInfoCircle} boxSize={3.5} mt={0.5} />
-                                <Text color="inherit" textAlign="left">
-                                    Sign in with your wallet to join this crypto game.
-                                </Text>
-                            </HStack>
-                        )}
-
-                        {/* Insufficient balance warning */}
-                        {isBalanceInsufficient && (
-                            <HStack spacing={2} alignItems="flex-start" bg="red.50" color="red.700" borderRadius="md" px={3} py={2} fontSize="xs" fontWeight="medium" width="100%">
-                                <Icon as={FaInfoCircle} boxSize={3.5} mt={0.5} />
-                                <Text color="inherit" textAlign="left">
-                                    Insufficient USDC balance{usdcBalance ? ` (balance: ${usdcBalance} USDC)` : ''}.
-                                </Text>
-                            </HStack>
-                        )}
-
-                        {/* Withdraw button */}
-                        {showWithdrawFirst && (
-                            <Button
-                                w="100%"
-                                h="50px"
-                                fontSize="md"
-                                fontWeight="bold"
-                                borderRadius="bigButton"
-                                bg="brand.pink"
-                                color="white"
-                                border="none"
-                                _hover={{ bg: 'brand.pink', transform: 'translateY(-2px)', boxShadow: '0 12px 24px rgba(255, 105, 135, 0.35)' }}
-                                transition="all 0.2s ease"
-                            >
-                                Withdraw chips &amp; start fresh
-                            </Button>
-                        )}
-
-                        {/* Join / Buy In button */}
-                        {!showWithdrawFirst && (
-                            <Button
-                                w="100%"
-                                h="50px"
-                                fontSize="md"
-                                fontWeight="bold"
-                                borderRadius="bigButton"
-                                bg={isJoinDisabled ? 'gray.300' : 'brand.green'}
-                                color={isJoinDisabled ? 'gray.500' : 'white'}
-                                border="none"
-                                cursor={isJoinDisabled ? 'not-allowed' : 'pointer'}
-                                _hover={isJoinDisabled ? {} : {
-                                    bg: 'brand.green',
-                                    transform: 'translateY(-2px)',
-                                    boxShadow: '0 12px 24px rgba(54, 163, 123, 0.35)',
+                                boxShadow={
+                                    isJoinDisabled
+                                        ? 'none'
+                                        : '0 6px 18px rgba(54, 163, 123, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.15)'
+                                }
+                                _hover={
+                                    isJoinDisabled
+                                        ? {}
+                                        : {
+                                              bg: '#2E8A66',
+                                              transform: 'translateY(-2px)',
+                                              boxShadow:
+                                                  '0 14px 28px rgba(54, 163, 123, 0.42), inset 0 1px 0 rgba(255, 255, 255, 0.22)',
+                                          }
+                                }
+                                _active={{
+                                    bg: isJoinDisabled
+                                        ? 'btn.lightGray'
+                                        : '#287859',
+                                    transform: isJoinDisabled
+                                        ? 'none'
+                                        : 'translateY(0) scale(0.99)',
                                 }}
                                 transition="all 0.2s ease"
                             >
-                                {isCryptoGame ? 'Buy In' : 'Join Game'}
+                                <Text
+                                    fontSize="md"
+                                    fontWeight="bold"
+                                    letterSpacing="-0.01em"
+                                    color={isJoinDisabled ? 'text.muted' : 'white'}
+                                >
+                                    {isCryptoGame
+                                        ? `Sit down · $${formattedUsdcEst}`
+                                        : 'Join game'}
+                                </Text>
                             </Button>
-                        )}
 
-                        {/* Crypto fine print */}
-                        {!showWithdrawFirst && isCryptoGame && (
-                            <Text fontSize="2xs" color="text.muted" textAlign="center" lineHeight="short" px={2} opacity={0.7}>
-                                Your USDC is deposited into the table contract and converted to chips.
-                                Chip balances update after each settled hand. {CHIPS_PER_USDC} chips&nbsp;=&nbsp;1&nbsp;USDC.{' '}
-                                <Link href="#" color="text.secondary" fontWeight="semibold" textDecoration="underline" textUnderlineOffset="2px">
-                                    View contract
-                                </Link>
-                            </Text>
-                        )}
-                    </VStack>
-                </Box>
-            </Box>
-
-            {/* Decorative blurs */}
-            <Box position="absolute" top="-20px" right="-20px" width="120px" height="120px" borderRadius="50%" bg="brand.pink" opacity={0.08} filter="blur(40px)" pointerEvents="none" />
-            <Box position="absolute" bottom="-30px" left="-30px" width="140px" height="140px" borderRadius="50%" bg="brand.green" opacity={0.08} filter="blur(50px)" pointerEvents="none" />
+                            {isCryptoGame && (
+                                <Box w="100%" pt={1}>
+                                    <Box
+                                        as="button"
+                                        type="button"
+                                        onClick={finePrint.onToggle}
+                                        w="100%"
+                                        display="flex"
+                                        alignItems="center"
+                                        justifyContent="center"
+                                        gap={1.5}
+                                        py={1}
+                                        cursor="pointer"
+                                        bg="transparent"
+                                        border="none"
+                                        opacity={0.85}
+                                        _hover={{ opacity: 1 }}
+                                    >
+                                        <Text
+                                            fontSize="xs"
+                                            color="text.secondary"
+                                            fontWeight="bold"
+                                        >
+                                            How does this work?
+                                        </Text>
+                                        <Icon
+                                            as={FaChevronDown}
+                                            boxSize={2.5}
+                                            color="text.secondary"
+                                            transform={
+                                                finePrint.isOpen
+                                                    ? 'rotate(180deg)'
+                                                    : 'rotate(0deg)'
+                                            }
+                                            transition="transform 0.2s ease"
+                                        />
+                                    </Box>
+                                    <Collapse in={finePrint.isOpen} animateOpacity>
+                                        <Text
+                                            fontSize="2xs"
+                                            color="text.muted"
+                                            textAlign="center"
+                                            lineHeight="short"
+                                            px={2}
+                                            pt={2}
+                                            opacity={0.75}
+                                        >
+                                            Your USDC is deposited into the table contract
+                                            and converted to chips. Chip balances update
+                                            after each settled hand. {CHIPS_PER_USDC} chips
+                                            &nbsp;=&nbsp;1&nbsp;USDC.{' '}
+                                            <Link
+                                                href="#"
+                                                color="brand.navy"
+                                                _dark={{ color: 'brand.lightGray' }}
+                                                fontWeight="semibold"
+                                                textDecoration="underline"
+                                                textUnderlineOffset="2px"
+                                            >
+                                                View contract
+                                            </Link>
+                                        </Text>
+                                    </Collapse>
+                                </Box>
+                            )}
+                        </VStack>
+                    </Box>
+                </>
+            )}
         </Box>
     );
 };
-
-// ── Meta ─────────────────────────────────────────────────────────────────────
 
 const meta = {
     title: 'Modals/TakeSeatModal',
@@ -543,7 +787,7 @@ const meta = {
     tags: ['autodocs'],
     decorators: [
         (Story) => (
-            <Box p={8} minH="600px" display="flex" alignItems="center" justifyContent="center">
+            <Box p={8} minH="700px" display="flex" alignItems="center" justifyContent="center">
                 <Story />
             </Box>
         ),
@@ -558,6 +802,12 @@ const meta = {
         showWithdrawFirst: { control: 'boolean' },
         existingChipBalance: { control: 'text' },
         isBalanceInsufficient: { control: 'boolean' },
+        sb: { control: 'number' },
+        bb: { control: 'number' },
+        maxBuyIn: { control: 'number' },
+        seatId: { control: 'number' },
+        chain: { control: 'text' },
+        defaultBuyInChips: { control: 'number' },
     },
     args: {
         isCryptoGame: true,
@@ -569,12 +819,18 @@ const meta = {
         showWithdrawFirst: false,
         existingChipBalance: null,
         isBalanceInsufficient: false,
+        sb: 10,
+        bb: 20,
+        maxBuyIn: 10000,
+        seatId: 3,
+        chain: 'Base',
+        defaultBuyInChips: 1000,
     },
     parameters: {
         docs: {
             description: {
                 component:
-                    'Take Seat modal — the main entry point for joining a poker table. Crypto games show a USDC deposit flow with Chips/USDC toggle. Free games show a username input or X-linked identity. X-linked players see their avatar and @handle in a compact card.',
+                    'Take Seat modal (direction C redesign) — stakes-led header, chip stack hero, BB-anchored preset pills that scale with blinds, and a dual-unit CTA. Crypto shows USDC deposit flow, free game shows username/X identity.',
             },
         },
     },
@@ -583,24 +839,63 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// ── Stories ──────────────────────────────────────────────────────────────────
-
-/** Crypto game with X account linked — avatar + @handle badge, USDC deposit flow. */
-export const CryptoXLinked: Story = {
-    name: 'Crypto — X linked',
+/** Low stakes crypto ($0.10/$0.20), X linked — the most common first-deposit flow. */
+export const CryptoMicroStakes: Story = {
+    name: 'Crypto · $0.10/$0.20 · X linked',
     args: {
         isCryptoGame: true,
         xUsername: '0xVoxin',
-        xProfileImageUrl: 'https://pbs.twimg.com/profile_images/1683325380441128960/yRsRRjGO_400x400.jpg',
+        xProfileImageUrl:
+            'https://pbs.twimg.com/profile_images/1683325380441128960/yRsRRjGO_400x400.jpg',
         usdcBalance: '82.41',
-        walletAddress: '0xFA04...445b',
+        walletAddress: '0xFA0412345678901234567890123456789012445b',
         isConnected: true,
+        sb: 10,
+        bb: 20,
+        maxBuyIn: 10000,
+        defaultBuyInChips: 1000,
     },
 };
 
-/** Crypto game, no X linked — shows Connect X button, no username input. */
+/** Mid stakes ($1/$2) — presets snap to $100/$250/$250(dedup)/Max. */
+export const CryptoMidStakes: Story = {
+    name: 'Crypto · $1/$2 · X linked',
+    args: {
+        isCryptoGame: true,
+        xUsername: '0xVoxin',
+        xProfileImageUrl:
+            'https://pbs.twimg.com/profile_images/1683325380441128960/yRsRRjGO_400x400.jpg',
+        usdcBalance: '1250.00',
+        walletAddress: '0xFA0412345678901234567890123456789012445b',
+        isConnected: true,
+        sb: 100,
+        bb: 200,
+        maxBuyIn: 60000,
+        defaultBuyInChips: 40000,
+    },
+};
+
+/** High stakes ($100/$200) — presets auto-scale to $10k/$20k/$25k/Max. */
+export const CryptoHighStakes: Story = {
+    name: 'Crypto · $100/$200 · X linked',
+    args: {
+        isCryptoGame: true,
+        xUsername: '0xVoxin',
+        xProfileImageUrl:
+            'https://pbs.twimg.com/profile_images/1683325380441128960/yRsRRjGO_400x400.jpg',
+        usdcBalance: '50000.00',
+        walletAddress: '0xFA0412345678901234567890123456789012445b',
+        isConnected: true,
+        sb: 10000,
+        bb: 20000,
+        maxBuyIn: 5000000,
+        defaultBuyInChips: 2000000,
+    },
+};
+
+/** Crypto, no X linked — shows Connect X affordance. */
 export const CryptoNoX: Story = {
-    name: 'Crypto — no X',
+    name: 'Crypto · no X',
     args: {
         isCryptoGame: true,
         xUsername: null,
@@ -610,43 +905,41 @@ export const CryptoNoX: Story = {
     },
 };
 
-/** Crypto game with X linked but no avatar image — fallback X circle. */
-export const CryptoXNoAvatar: Story = {
-    name: 'Crypto — X linked (no avatar)',
-    args: {
-        isCryptoGame: true,
-        xUsername: 'stackedPoker',
-        xProfileImageUrl: null,
-        usdcBalance: '150.00',
-        walletAddress: '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
-        isConnected: true,
-    },
-};
-
-/** Free game with X linked — avatar + @handle, no buy-in currency toggle. */
+/** Free game, X linked — chip-denominated presets, no USDC flow. */
 export const FreeXLinked: Story = {
-    name: 'Free game — X linked',
+    name: 'Free · X linked',
     args: {
         isCryptoGame: false,
         xUsername: 'pokerShark',
-        xProfileImageUrl: 'https://pbs.twimg.com/profile_images/1590968738358079488/IY9Gx6Ok_400x400.jpg',
+        xProfileImageUrl:
+            'https://pbs.twimg.com/profile_images/1590968738358079488/IY9Gx6Ok_400x400.jpg',
         isConnected: true,
+        sb: 10,
+        bb: 20,
+        maxBuyIn: 5000,
+        defaultBuyInChips: 2000,
+        chain: undefined,
     },
 };
 
-/** Free game, no X — shows Connect X button + username input with "or" divider. */
+/** Free game, no X — shows username input with divider. */
 export const FreeNoX: Story = {
-    name: 'Free game — no X',
+    name: 'Free · no X',
     args: {
         isCryptoGame: false,
         xUsername: null,
         isConnected: true,
+        sb: 10,
+        bb: 20,
+        maxBuyIn: 5000,
+        defaultBuyInChips: 2000,
+        chain: undefined,
     },
 };
 
-/** Crypto game, wallet not connected — shows Sign In button + wallet hint. */
+/** Crypto, wallet not connected — Sign In button + hint banner. */
 export const CryptoNotConnected: Story = {
-    name: 'Crypto — wallet not connected',
+    name: 'Crypto · wallet not connected',
     args: {
         isCryptoGame: true,
         xUsername: null,
@@ -656,31 +949,34 @@ export const CryptoNotConnected: Story = {
     },
 };
 
-/** Crypto with existing chips — withdraw-first flow with warning banner. */
-export const WithdrawFirst: Story = {
-    name: 'Crypto — withdraw first',
+/** Insufficient balance — red warning banner + greyed chip stack. */
+export const InsufficientBalance: Story = {
+    name: 'Crypto · insufficient balance',
     args: {
         isCryptoGame: true,
         xUsername: '0xVoxin',
-        xProfileImageUrl: 'https://pbs.twimg.com/profile_images/1683325380441128960/yRsRRjGO_400x400.jpg',
+        xProfileImageUrl:
+            'https://pbs.twimg.com/profile_images/1683325380441128960/yRsRRjGO_400x400.jpg',
+        usdcBalance: '2.50',
+        walletAddress: '0xFA0412345678901234567890123456789012445b',
+        isConnected: true,
+        isBalanceInsufficient: true,
+        defaultBuyInChips: 1000,
+    },
+};
+
+/** Existing chips on contract — full-face takeover, withdraw first. */
+export const WithdrawFirst: Story = {
+    name: 'Crypto · withdraw first (takeover)',
+    args: {
+        isCryptoGame: true,
+        xUsername: '0xVoxin',
+        xProfileImageUrl:
+            'https://pbs.twimg.com/profile_images/1683325380441128960/yRsRRjGO_400x400.jpg',
         usdcBalance: '82.41',
         walletAddress: '0xFA0412345678901234567890123456789012445b',
         isConnected: true,
         showWithdrawFirst: true,
         existingChipBalance: '5,000',
-    },
-};
-
-/** Crypto with insufficient balance — error banner shown. */
-export const InsufficientBalance: Story = {
-    name: 'Crypto — insufficient balance',
-    args: {
-        isCryptoGame: true,
-        xUsername: '0xVoxin',
-        xProfileImageUrl: 'https://pbs.twimg.com/profile_images/1683325380441128960/yRsRRjGO_400x400.jpg',
-        usdcBalance: '2.50',
-        walletAddress: '0xFA0412345678901234567890123456789012445b',
-        isConnected: true,
-        isBalanceInsufficient: true,
     },
 };

--- a/app/components/TakeSeatModal.tsx
+++ b/app/components/TakeSeatModal.tsx
@@ -15,7 +15,6 @@ import {
     FormControl,
     FormErrorMessage,
     VStack,
-    Center,
     HStack,
     Text,
     Heading,
@@ -23,6 +22,8 @@ import {
     Flex,
     Icon,
     Link,
+    Collapse,
+    useDisclosure,
 } from '@chakra-ui/react';
 import { motion, MotionStyle } from 'framer-motion';
 import { keyframes } from '@emotion/react';
@@ -36,9 +37,12 @@ import useToastHelper from '@/app/hooks/useToastHelper';
 import { useDepositAndJoin } from '../hooks/useDepositAndJoin';
 import { useWithdraw } from '../hooks/useWithdraw';
 import { useActiveWallet } from 'thirdweb/react';
-import { FaInfoCircle } from 'react-icons/fa';
+import { FaInfoCircle, FaChevronDown } from 'react-icons/fa';
 import { FaXTwitter } from 'react-icons/fa6';
 import { useConnectX } from '@/app/hooks/useConnectX';
+import BuyInPresets from './TakeSeat/BuyInPresets';
+import StakesChip from './TakeSeat/StakesChip';
+import { readLastBuyIn, writeLastBuyIn } from '@/app/lib/takeSeat/lastBuyIn';
 
 interface TakeSeatModalProps {
     isOpen: boolean;
@@ -46,27 +50,14 @@ interface TakeSeatModalProps {
     seatId?: number;
 }
 
-// Animations
-const gradientShift = keyframes`
-    0% { background-position: 0% 50%; }
-    50% { background-position: 100% 50%; }
-    100% { background-position: 0% 50%; }
-`;
-
 const float = keyframes`
     0%, 100% { transform: translateY(0px); }
     50% { transform: translateY(-6px); }
 `;
 
 const slideUp = keyframes`
-    from { 
-        opacity: 0; 
-        transform: translateY(30px); 
-    }
-    to { 
-        opacity: 1; 
-        transform: translateY(0); 
-    }
+    from { opacity: 0; transform: translateY(24px); }
+    to   { opacity: 1; transform: translateY(0); }
 `;
 
 const motionStyle: MotionStyle = {
@@ -80,7 +71,6 @@ const variants = {
 
 const USERNAME_MAX_LENGTH = 9;
 const CHIPS_PER_USDC = 100;
-const USDC_LOGO_URL = '/usdc-logo.png';
 
 const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
     const wallet = useActiveWallet();
@@ -89,7 +79,17 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
     const config = appStore.appState.game?.config;
     const isCryptoGame = Boolean(config?.crypto);
     const contractAddress = config?.contractAddress;
-    const initialBuyIn = config?.maxBuyIn ?? null;
+    const chain = config?.chain;
+    const sb = config?.sb ?? 0;
+    const bb = config?.bb ?? 0;
+    const maxBuyIn = config?.maxBuyIn ?? 0;
+
+    // Table id for localStorage persistence (contract address for crypto;
+    // chain+blinds hash fallback for free games so different tables don't collide).
+    const tableKey =
+        contractAddress ??
+        (bb > 0 ? `free:${sb}-${bb}-${maxBuyIn}` : null);
+
     const currentUser = useCurrentUser();
     const socket = useContext(SocketContext);
     const {
@@ -100,22 +100,28 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
         xProfileImageUrl,
     } = useAuth();
     const { connectX, isConnecting: isConnectingX } = useConnectX();
+
+    // Buy-in initial value: last-used for this table → max buy-in
+    const initialBuyIn = useMemo(() => {
+        const remembered = readLastBuyIn(tableKey);
+        if (remembered && remembered > 0) return remembered;
+        return maxBuyIn > 0 ? maxBuyIn : null;
+    }, [tableKey, maxBuyIn]);
+
     const [name, setName] = useState('');
     const [buyIn, setBuyIn] = useState<number | null>(initialBuyIn);
     const [buyInInput, setBuyInInput] = useState(() => {
-        if (initialBuyIn === null || isNaN(Number(initialBuyIn))) {
-            return '';
-        }
+        if (initialBuyIn === null) return '';
         if (isCryptoGame) {
             const usdcValue = initialBuyIn / CHIPS_PER_USDC;
-            const rounded = Math.round(usdcValue * 100) / 100;
-            return rounded.toString();
+            return (Math.round(usdcValue * 100) / 100).toString();
         }
         return initialBuyIn.toString();
     });
     const [inputUnit, setInputUnit] = useState<'chips' | 'usdc'>(
         isCryptoGame ? 'usdc' : 'chips'
     );
+
     const { error, deposit } = useToastHelper();
     const needsWalletSignIn = isCryptoGame && (!address || !isAuthenticated);
     const cryptoJoinHint = !address
@@ -124,7 +130,6 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
           ? 'Check your wallet to sign the message…'
           : 'Sign the message in your wallet to continue.';
 
-    // Crypto deposit hook
     const {
         depositAndJoin,
         status: depositStatus,
@@ -135,7 +140,6 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
         refreshBalance,
     } = useDepositAndJoin(contractAddress);
 
-    // Withdraw hook — used to detect and clear existing chip balance before re-depositing
     const {
         withdraw,
         checkCanWithdraw,
@@ -149,7 +153,6 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
     const seatRequested = appStore.appState.seatRequested;
     const hasExistingChips =
         existingChipBalance !== null && existingChipBalance > BigInt(0);
-    // Show withdraw-first flow when user has chips in the contract but no active seat request
     const showWithdrawFirst =
         isCryptoGame && hasExistingChips && seatRequested === null;
 
@@ -158,7 +161,6 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
         return Number(existingChipBalance).toLocaleString('en-US');
     }, [existingChipBalance]);
 
-    // When X is linked, use @xUsername automatically — no manual name needed
     const effectiveName = !isCryptoGame && xUsername ? `@${xUsername}` : name;
     const isNameInvalid =
         !isCryptoGame &&
@@ -167,6 +169,12 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
     const isBuyInInvalid = buyIn === null || isNaN(Number(buyIn)) || buyIn <= 0;
     const isJoinDisabled = isDepositing || isNameInvalid || isBuyInInvalid;
     const isJoinVisuallyDisabled = isJoinDisabled || needsWalletSignIn;
+
+    const walletBalanceChips = useMemo(() => {
+        if (!isCryptoGame || usdcBalance === null) return null;
+        const dollars = Number(usdcBalance) / 1_000_000;
+        return Math.floor(dollars * CHIPS_PER_USDC);
+    }, [isCryptoGame, usdcBalance]);
 
     const formattedUsdcBalance = useMemo(() => {
         if (usdcBalance === null) return null;
@@ -178,9 +186,7 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
     }, [usdcBalance]);
 
     const buyInUsdc = useMemo(() => {
-        if (!isCryptoGame || buyIn === null || isNaN(Number(buyIn))) {
-            return null;
-        }
+        if (!isCryptoGame || buyIn === null || isNaN(Number(buyIn))) return null;
         return buyIn / CHIPS_PER_USDC;
     }, [buyIn, isCryptoGame]);
 
@@ -205,8 +211,21 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
 
     const formatUsdcInput = (value: number) => {
         if (!Number.isFinite(value)) return '';
-        const rounded = Math.round(value * 100) / 100;
-        return rounded.toString();
+        return (Math.round(value * 100) / 100).toString();
+    };
+
+    const applyBuyInChips = (chips: number) => {
+        if (chips <= 0) {
+            setBuyIn(null);
+            setBuyInInput('');
+            return;
+        }
+        setBuyIn(chips);
+        if (isCryptoGame && inputUnit === 'usdc') {
+            setBuyInInput(formatUsdcInput(chips / CHIPS_PER_USDC));
+        } else {
+            setBuyInInput(Math.round(chips).toString());
+        }
     };
 
     const handleBuyInChange = (value: string) => {
@@ -218,110 +237,71 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
                     setBuyIn(null);
                     return;
                 }
-                const usdcValue = Number(value);
-                setBuyIn(Math.round(usdcValue * CHIPS_PER_USDC));
+                setBuyIn(Math.round(Number(value) * CHIPS_PER_USDC));
                 return;
             }
-
             if (!/^\d*$/.test(value)) return;
             setBuyInInput(value);
-            if (value === '') {
-                setBuyIn(null);
-                return;
-            }
-            const chips = Number(value);
-            setBuyIn(chips);
+            setBuyIn(value === '' ? null : Number(value));
             return;
         }
-
         if (!/^\d*$/.test(value)) return;
         setBuyInInput(value);
-        if (value === '') {
-            setBuyIn(null);
-            return;
-        }
-        setBuyIn(Number(value));
+        setBuyIn(value === '' ? null : Number(value));
     };
 
     const handleJoin = async () => {
-        // Basic validation for seatId, buyIn
-        if (!seatId) {
-            error('Missing Information', 'Seat ID is missing.');
-            return;
-        }
-        if (isBuyInInvalid) {
-            error('Invalid Amount', 'Please enter a valid buy-in amount.');
-            return;
-        }
-        if (buyIn === null) {
-            return;
-        }
-        if (needsWalletSignIn) {
-            error('Authentication Required', cryptoJoinHint);
-            return;
-        }
+        if (!seatId) return error('Missing Information', 'Seat ID is missing.');
+        if (isBuyInInvalid)
+            return error('Invalid Amount', 'Please enter a valid buy-in amount.');
+        if (buyIn === null) return;
+        if (needsWalletSignIn)
+            return error('Authentication Required', cryptoJoinHint);
 
         const buyInValue = buyIn;
 
-        // Crypto game flow: deposit via smart contract
         if (isCryptoGame) {
-            if (!contractAddress) {
-                error('Contract Error', 'Game contract address not available.');
-                return;
-            }
-
-            // Guard: active wallet must match the authenticated JWT wallet.
-            // If they differ, the on-chain tx would come from a different address
-            // than the one the backend has on record, causing the deposit to be
-            // treated as a stranger's seat request instead of the owner's.
-            if (address?.toLowerCase() !== lastAuthenticatedAddress?.toLowerCase()) {
-                error(
+            if (!contractAddress)
+                return error('Contract Error', 'Game contract address not available.');
+            if (
+                address?.toLowerCase() !==
+                lastAuthenticatedAddress?.toLowerCase()
+            ) {
+                return error(
                     'Wallet Mismatch',
                     `Your active wallet doesn't match your authenticated session. Switch back to ${lastAuthenticatedAddress ? lastAuthenticatedAddress.slice(0, 6) + '...' + lastAuthenticatedAddress.slice(-4) : 'your original wallet'} or re-authenticate.`
                 );
-                return;
             }
-
             const depositSuccess = await depositAndJoin(buyInValue);
-
             if (depositSuccess) {
+                writeLastBuyIn(tableKey, buyInValue);
                 appStore.dispatch({ type: 'setSeatRequested', payload: seatId });
                 deposit(buyInValue, isCryptoGame);
                 onClose();
-            } else {
-                // Error is already set in the hook, just show it
-                if (depositError) {
-                    error('Deposit Failed', depositError);
-                }
+            } else if (depositError) {
+                error('Deposit Failed', depositError);
             }
             return;
         }
 
-        // Regular game flow: WebSocket
-        if (!socket) {
-            error('Connection Error', 'Unable to connect to the server.');
-            return;
-        }
-        if (effectiveName.length === 0) {
-            error('Missing Information', 'Please enter a username.');
-            return;
-        }
-        if (!xUsername && effectiveName.length > USERNAME_MAX_LENGTH) {
-            error(
+        if (!socket)
+            return error('Connection Error', 'Unable to connect to the server.');
+        if (effectiveName.length === 0)
+            return error('Missing Information', 'Please enter a username.');
+        if (!xUsername && effectiveName.length > USERNAME_MAX_LENGTH)
+            return error(
                 'Invalid Username',
                 `Username must be fewer than 10 characters.`
             );
-            return;
-        }
-        if (!xUsername && effectiveName.startsWith('@')) {
-            error(
+        if (!xUsername && effectiveName.startsWith('@'))
+            return error(
                 'Reserved Username',
                 'The @ prefix is reserved for linked X accounts. Connect your X account in Settings to use your handle.'
             );
-            return;
-        }
+
         newPlayer(socket, effectiveName);
         takeSeat(socket, effectiveName, seatId, buyInValue);
+        writeLastBuyIn(tableKey, buyInValue);
         appStore.dispatch({ type: 'setUsername', payload: effectiveName });
         appStore.dispatch({ type: 'setSeatRequested', payload: seatId });
         currentUser.setCurrentUser({ name: effectiveName, seatId });
@@ -329,9 +309,7 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
     };
 
     useEffect(() => {
-        if (!isCryptoGame && inputUnit !== 'chips') {
-            setInputUnit('chips');
-        }
+        if (!isCryptoGame && inputUnit !== 'chips') setInputUnit('chips');
     }, [inputUnit, isCryptoGame]);
 
     const handleUnitChange = (unit: 'chips' | 'usdc') => {
@@ -353,7 +331,6 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
         refreshBalance();
     }, [isOpen, isCryptoGame, refreshBalance]);
 
-    // Check for existing chip balance on modal open
     useEffect(() => {
         if (!isOpen || !isCryptoGame || !address) return;
         checkCanWithdraw();
@@ -361,20 +338,15 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
 
     const handleWithdraw = async () => {
         const success = await withdraw();
-        if (success) {
-            // Chip balance is now 0 — refresh USDC balance since user got USDC back
-            refreshBalance();
-        }
+        if (success) refreshBalance();
     };
 
-    // Reset deposit state when modal closes
     const handleClose = () => {
         resetDeposit();
         resetWithdraw();
         onClose();
     };
 
-    // Get status message for crypto deposit
     const getDepositStatusMessage = () => {
         switch (depositStatus) {
             case 'checking_allowance':
@@ -388,222 +360,265 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
         }
     };
 
+    // Fine-print disclosure: default open on first crypto deposit, collapsed after.
+    const finePrintDisclosure = useDisclosure({
+        defaultIsOpen:
+            isCryptoGame && !readLastBuyIn(tableKey),
+    });
+
     return (
         <Modal isOpen={isOpen} onClose={handleClose} isCentered>
             <ModalOverlay bg="rgba(0, 0, 0, 0.7)" backdropFilter="blur(8px)" />
             <ModalContent
-                zIndex={'modal'}
-                borderRadius="32px"
-                maxWidth="420px"
-                minWidth="320px"
+                zIndex="modal"
+                borderRadius={{ base: '24px', sm: '28px' }}
+                maxWidth={{ base: 'calc(100vw - 24px)', sm: '420px' }}
+                mx={{ base: 3, sm: 'auto' }}
                 boxShadow="0 20px 60px rgba(0, 0, 0, 0.25), 0 0 0 1px rgba(0, 0, 0, 0.05)"
-                animation={`${slideUp} 0.4s ease-out`}
+                animation={`${slideUp} 0.35s cubic-bezier(0.2, 0.9, 0.3, 1)`}
                 overflow="hidden"
                 position="relative"
+                bg="card.white"
                 border="1px solid"
-                borderColor="card.white"
+                borderColor="border.lightGray"
             >
-                {/* Animated Gradient Border */}
-                <Box
-                    position="absolute"
-                    top={0}
-                    left={0}
-                    right={0}
-                    bottom={0}
-                    borderRadius="32px"
-                    padding="3px"
-                    bgGradient="linear(to-r, brand.pink, brand.green, brand.yellow, brand.pink)"
-                    backgroundSize="200% 200%"
-                    animation={`${gradientShift} 8s ease infinite`}
-                    pointerEvents="none"
-                    zIndex={0}
+                {/* Easter egg chair — bottom-right, quiet */}
+                <Tooltip
+                    label='"All you need is a chip and a chair." — Jack Straus'
+                    fontSize="xs"
+                    placement="top"
+                    bg="brand.navy"
+                    color="white"
+                    borderRadius="lg"
+                    px={3}
+                    py={1.5}
                 >
                     <Box
-                        width="100%"
-                        height="100%"
-                        bg="card.white"
-                        borderRadius="29px"
-                    />
-                </Box>
-
-                {/* Content Container */}
-                <Box position="relative" zIndex={1} bg={'card.white'}>
-                    {/* Easter egg chair */}
-                    <Tooltip
-                        label='"All you need is a chip and a chair." — Jack Straus'
-                        fontSize="xs"
-                        placement="bottom"
-                        bg="brand.navy"
-                        color="white"
-                        borderRadius="lg"
-                        px={3}
-                        py={1.5}
-                    >
-                        <Box
-                            as={motion.div}
-                            position="absolute"
-                            top={3}
-                            left={4}
-                            style={motionStyle}
-                            variants={variants}
-                            initial="initial"
-                            whileHover="hover"
-                            fontSize="xl"
-                            animation={`${float} 5s ease-in-out infinite`}
-                            cursor="pointer"
-                            zIndex={2}
-                            opacity={0.7}
-                        >
-                            🪑
-                        </Box>
-                    </Tooltip>
-
-                    <ModalCloseButton
-                        color="text.secondary"
-                        size="md"
-                        top={3}
+                        as={motion.div}
+                        position="absolute"
+                        bottom={3}
                         right={3}
-                        borderRadius="full"
-                        _hover={{
-                            bg: 'card.lightGray',
-                            transform: 'rotate(90deg)',
-                        }}
-                        transition="all 0.3s cubic-bezier(0.4, 0, 0.2, 1)"
-                    />
+                        style={motionStyle}
+                        variants={variants}
+                        initial="initial"
+                        whileHover="hover"
+                        fontSize="sm"
+                        animation={`${float} 5s ease-in-out infinite`}
+                        cursor="pointer"
+                        zIndex={2}
+                        opacity={0.35}
+                        _hover={{ opacity: 1 }}
+                        transition="opacity 0.2s ease"
+                    >
+                        🪑
+                    </Box>
+                </Tooltip>
 
-                    <ModalHeader textAlign="center" pt={10} pb={2} px={8}>
-                        <VStack spacing={1}>
-                            <Heading
-                                as="h2"
-                                fontSize="xl"
-                                fontWeight="bold"
-                                color="text.secondary"
-                                letterSpacing="-0.02em"
-                            >
-                                Take your seat
-                            </Heading>
-                            <Text
-                                fontSize="xs"
-                                color="text.muted"
-                                fontWeight="medium"
-                                textAlign="center"
-                            >
-                                {isCryptoGame
-                                    ? 'Deposit USDC to join the table'
-                                    : 'Join the table and start playing'}
-                            </Text>
-                        </VStack>
-                    </ModalHeader>
+                <ModalCloseButton
+                    color="text.secondary"
+                    size="md"
+                    top={3}
+                    right={3}
+                    borderRadius="full"
+                    _hover={{
+                        bg: 'card.lightGray',
+                        transform: 'rotate(90deg)',
+                    }}
+                    transition="all 0.3s cubic-bezier(0.4, 0, 0.2, 1)"
+                />
 
-                    <ModalBody px={7} pb={3} pt={1}>
-                        <Center>
-                            <VStack w="100%" spacing={4}>
-                                {/* Withdraw-first state: user has chips in the contract but no active seat request */}
-                                {showWithdrawFirst && (
-                                    <VStack
-                                        w="100%"
-                                        spacing={3}
-                                        bg="orange.50"
-                                        borderRadius="xl"
-                                        px={4}
-                                        py={4}
-                                        border="1px solid"
-                                        borderColor="orange.200"
-                                    >
-                                        <HStack
-                                            spacing={2}
-                                            alignItems="flex-start"
-                                            w="100%"
+                {showWithdrawFirst ? (
+                    /* ── Withdraw-first takeover ─────────────────────────── */
+                    <>
+                        <ModalHeader textAlign="center" pt={10} pb={2} px={6}>
+                            <VStack spacing={2}>
+                                <Heading
+                                    as="h2"
+                                    fontSize="xl"
+                                    fontWeight="bold"
+                                    color="text.secondary"
+                                    letterSpacing="-0.02em"
+                                >
+                                    Chips still on this table
+                                </Heading>
+                                <StakesChip
+                                    sb={sb}
+                                    bb={bb}
+                                    seatId={seatId}
+                                    isCrypto={isCryptoGame}
+                                    chain={chain}
+                                />
+                            </VStack>
+                        </ModalHeader>
+                        <ModalBody px={{ base: 5, sm: 7 }} pb={2} pt={2}>
+                            <VStack spacing={4} w="100%">
+                                <Box
+                                    w="100%"
+                                    bg="card.lightGray"
+                                    borderRadius="xl"
+                                    px={5}
+                                    py={5}
+                                    textAlign="center"
+                                >
+                                    <VStack spacing={2}>
+                                        <Text
+                                            fontSize="3xl"
+                                            fontWeight="bold"
+                                            color="text.secondary"
+                                            letterSpacing="-0.02em"
+                                            lineHeight={1}
                                         >
-                                            <Icon
-                                                as={FaInfoCircle}
-                                                boxSize={4}
-                                                color="orange.500"
-                                                mt={0.5}
-                                                flexShrink={0}
-                                            />
-                                            <VStack
-                                                spacing={1}
-                                                alignItems="flex-start"
-                                            >
-                                                <Text
-                                                    fontSize="sm"
-                                                    fontWeight="semibold"
-                                                    color="orange.700"
-                                                >
-                                                    Chips already in contract
-                                                </Text>
-                                                <Text
-                                                    fontSize="xs"
-                                                    color="orange.600"
-                                                    lineHeight="short"
-                                                >
-                                                    You have{' '}
-                                                    {formattedExistingChips}{' '}
-                                                    chips sitting in this
-                                                    contract from a previous
-                                                    deposit. Withdraw them first,
-                                                    then deposit a new amount to
-                                                    join.
-                                                </Text>
-                                            </VStack>
-                                        </HStack>
+                                            {formattedExistingChips ?? '—'}
+                                        </Text>
+                                        <Text
+                                            fontSize="xs"
+                                            color="text.muted"
+                                            fontWeight="medium"
+                                            textTransform="uppercase"
+                                            letterSpacing="0.05em"
+                                        >
+                                            chips in contract
+                                        </Text>
                                     </VStack>
-                                )}
-
-                                {/* Identity: X-linked banner (free game only — @handle is used as display name) */}
-                                {!showWithdrawFirst && !isCryptoGame && xUsername && (
+                                </Box>
+                                <Text
+                                    fontSize="sm"
+                                    color="text.secondary"
+                                    textAlign="center"
+                                    lineHeight="short"
+                                    px={2}
+                                >
+                                    Withdraw these to your wallet first, then you can
+                                    deposit a new amount and take your seat.
+                                </Text>
+                            </VStack>
+                        </ModalBody>
+                        <ModalFooter px={{ base: 5, sm: 7 }} pb={7} pt={4}>
+                            <VStack w="100%" spacing={3}>
+                                <WalletButton width="100%" height="52px" />
+                                {withdrawStatus === 'error' && withdrawError && (
                                     <HStack
-                                        spacing={3}
-                                        py={2}
+                                        spacing={2}
+                                        alignItems="flex-start"
+                                        bg="red.50"
+                                        borderRadius="md"
                                         px={3}
+                                        py={2}
+                                        width="100%"
+                                    >
+                                        <Icon
+                                            as={FaInfoCircle}
+                                            boxSize={3.5}
+                                            mt={0.5}
+                                            color="red.700"
+                                        />
+                                        <Text
+                                            fontSize="xs"
+                                            fontWeight="semibold"
+                                            color="red.700"
+                                            textAlign="left"
+                                            wordBreak="break-word"
+                                        >
+                                            {withdrawError}
+                                        </Text>
+                                    </HStack>
+                                )}
+                                <Button
+                                    w="100%"
+                                    h="52px"
+                                    borderRadius="bigButton"
+                                    bg="brand.pink"
+                                    isLoading={isWithdrawing}
+                                    loadingText="Withdrawing chips..."
+                                    _hover={{
+                                        bg: 'brand.pink',
+                                        transform: 'translateY(-2px)',
+                                        boxShadow:
+                                            '0 12px 24px rgba(235, 11, 92, 0.3)',
+                                    }}
+                                    transition="all 0.2s ease"
+                                    onClick={handleWithdraw}
+                                >
+                                    <Text
+                                        fontSize="md"
+                                        fontWeight="bold"
+                                        color="white"
+                                    >
+                                        Withdraw &amp; start fresh
+                                    </Text>
+                                </Button>
+                            </VStack>
+                        </ModalFooter>
+                    </>
+                ) : (
+                    /* ── Normal join flow ────────────────────────────────── */
+                    <>
+                        <ModalHeader textAlign="center" pt={10} pb={2} px={6}>
+                            <VStack spacing={1.5}>
+                                <Heading
+                                    as="h2"
+                                    fontSize="xl"
+                                    fontWeight="bold"
+                                    color="text.secondary"
+                                    letterSpacing="-0.02em"
+                                >
+                                    Take your seat
+                                </Heading>
+                                <StakesChip
+                                    sb={sb}
+                                    bb={bb}
+                                    seatId={seatId}
+                                    isCrypto={isCryptoGame}
+                                    chain={chain}
+                                />
+                            </VStack>
+                        </ModalHeader>
+
+                        <ModalBody px={{ base: 5, sm: 7 }} pb={2} pt={2}>
+                            <VStack w="100%" spacing={4}>
+                                {/* Identity */}
+                                {xUsername ? (
+                                    <HStack
+                                        spacing={2}
+                                        py={1}
                                         w="100%"
-                                        bg="card.lightGray"
-                                        borderRadius="xl"
+                                        justify="center"
                                     >
                                         {xProfileImageUrl ? (
                                             <Image
                                                 src={xProfileImageUrl}
                                                 alt="X avatar"
-                                                boxSize="34px"
+                                                boxSize="22px"
                                                 borderRadius="full"
                                                 objectFit="cover"
                                                 flexShrink={0}
                                             />
                                         ) : (
                                             <Flex
-                                                boxSize="34px"
+                                                boxSize="22px"
                                                 borderRadius="full"
                                                 bg="black"
                                                 alignItems="center"
                                                 justifyContent="center"
                                                 flexShrink={0}
                                             >
-                                                <Icon as={FaXTwitter} boxSize={3.5} color="white" />
+                                                <Icon
+                                                    as={FaXTwitter}
+                                                    boxSize={2.5}
+                                                    color="white"
+                                                />
                                             </Flex>
                                         )}
-                                        <HStack spacing={1.5} flex={1} minW={0}>
-                                            <Icon
-                                                as={FaXTwitter}
-                                                boxSize="11px"
-                                                color="text.primary"
-                                                opacity={0.5}
-                                                flexShrink={0}
-                                            />
-                                            <Text
-                                                fontSize="sm"
-                                                fontWeight="bold"
-                                                color="text.secondary"
-                                                noOfLines={1}
-                                            >
-                                                @{xUsername}
-                                            </Text>
-                                        </HStack>
+                                        <Text
+                                            fontSize="sm"
+                                            fontWeight="semibold"
+                                            color="text.secondary"
+                                            noOfLines={1}
+                                        >
+                                            @{xUsername}
+                                        </Text>
                                     </HStack>
-                                )}
-
-                                {/* Identity: no X linked — show Connect X option + (free only) name input */}
-                                {!showWithdrawFirst && !xUsername && (
+                                ) : (
                                     <VStack spacing={3} w="100%">
                                         <HStack
                                             as="button"
@@ -616,17 +631,29 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
                                             cursor="pointer"
                                             bg="transparent"
                                             border="none"
-                                            opacity={0.55}
+                                            opacity={0.6}
                                             _hover={{ opacity: 1 }}
-                                            _disabled={{ opacity: 0.3, cursor: 'not-allowed' }}
+                                            _disabled={{
+                                                opacity: 0.3,
+                                                cursor: 'not-allowed',
+                                            }}
                                             transition="opacity 0.15s ease"
                                         >
-                                            <Icon as={FaXTwitter} boxSize={3.5} color="text.primary" />
-                                            <Text fontSize="sm" fontWeight="medium" color="text.secondary">
-                                                {isConnectingX ? 'Connecting…' : 'Sign in with X'}
+                                            <Icon
+                                                as={FaXTwitter}
+                                                boxSize={3.5}
+                                                color="text.primary"
+                                            />
+                                            <Text
+                                                fontSize="sm"
+                                                fontWeight="medium"
+                                                color="text.secondary"
+                                            >
+                                                {isConnectingX
+                                                    ? 'Connecting…'
+                                                    : 'Sign in with X'}
                                             </Text>
                                         </HStack>
-
                                         {!isCryptoGame && (
                                             <>
                                                 <HStack
@@ -653,7 +680,6 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
                                                         bg="border.lightGray"
                                                     />
                                                 </HStack>
-
                                                 <FormControl
                                                     isInvalid={
                                                         name.length > 0 &&
@@ -667,7 +693,7 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
                                                         onChange={(e) =>
                                                             setName(e.target.value)
                                                         }
-                                                        variant={'takeSeatModal'}
+                                                        variant="takeSeatModal"
                                                         maxLength={USERNAME_MAX_LENGTH}
                                                         required
                                                     />
@@ -681,77 +707,28 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
                                     </VStack>
                                 )}
 
-                                {/* Identity: crypto game with X linked — compact inline card above buy-in */}
-                                {!showWithdrawFirst && isCryptoGame && xUsername && (
-                                    <HStack
-                                        spacing={3}
-                                        py={2}
-                                        px={3}
-                                        w="100%"
-                                        bg="card.lightGray"
-                                        borderRadius="xl"
-                                    >
-                                        {xProfileImageUrl ? (
-                                            <Image
-                                                src={xProfileImageUrl}
-                                                alt="X avatar"
-                                                boxSize="34px"
-                                                borderRadius="full"
-                                                objectFit="cover"
-                                                flexShrink={0}
-                                            />
-                                        ) : (
-                                            <Flex
-                                                boxSize="34px"
-                                                borderRadius="full"
-                                                bg="black"
-                                                alignItems="center"
-                                                justifyContent="center"
-                                                flexShrink={0}
-                                            >
-                                                <Icon as={FaXTwitter} boxSize={3.5} color="white" />
-                                            </Flex>
-                                        )}
-                                        <HStack spacing={1.5} flex={1} minW={0}>
-                                            <Icon
-                                                as={FaXTwitter}
-                                                boxSize="11px"
-                                                color="text.primary"
-                                                opacity={0.5}
-                                                flexShrink={0}
-                                            />
-                                            <Text
-                                                fontSize="sm"
-                                                fontWeight="bold"
-                                                color="text.secondary"
-                                                noOfLines={1}
-                                            >
-                                                @{xUsername}
-                                            </Text>
-                                        </HStack>
-                                    </HStack>
-                                )}
-
-                                {/* Buy-in Input — hidden while withdraw-first flow is active */}
-                                {!showWithdrawFirst && <FormControl>
+                                {/* Buy-in: hero input */}
+                                <FormControl>
+                                    {/* Header row: label + unit toggle (crypto only) */}
                                     <Flex
                                         alignItems="center"
                                         justifyContent="space-between"
-                                        mb={1.5}
+                                        mb={2}
                                     >
                                         <Text
-                                            fontSize="xs"
-                                            fontWeight="semibold"
-                                            color="text.secondary"
-                                            textTransform="none"
+                                            fontSize="2xs"
+                                            color="text.muted"
+                                            fontWeight="bold"
+                                            textTransform="uppercase"
+                                            letterSpacing="0.06em"
                                         >
-                                            Buy-in amount
+                                            Buy-in
                                         </Text>
                                         {isCryptoGame && (
                                             <Box
                                                 position="relative"
-                                                width="140px"
-                                                height="28px"
+                                                width="120px"
+                                                height="26px"
                                             >
                                                 <Box
                                                     position="absolute"
@@ -765,14 +742,14 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
                                                     left={
                                                         inputUnit === 'chips'
                                                             ? '3px'
-                                                            : 'calc(50% + 3px)'
+                                                            : 'calc(50% + 1px)'
                                                     }
-                                                    width="calc(50% - 6px)"
-                                                    height="22px"
+                                                    width="calc(50% - 4px)"
+                                                    height="20px"
                                                     bg="card.white"
                                                     borderRadius="full"
                                                     boxShadow="sm"
-                                                    transition="left 0.25s cubic-bezier(0.4, 0, 0.2, 1)"
+                                                    transition="left 0.22s cubic-bezier(0.4, 0, 0.2, 1)"
                                                 />
                                                 <Flex
                                                     position="relative"
@@ -781,510 +758,406 @@ const TakeSeatModal = ({ isOpen, onClose, seatId }: TakeSeatModalProps) => {
                                                     justifyContent="space-between"
                                                     height="full"
                                                 >
-                                                    <Box
-                                                        as="button"
-                                                        type="button"
-                                                        flex="1"
-                                                        height="full"
-                                                        display="flex"
-                                                        alignItems="center"
-                                                        justifyContent="center"
-                                                        cursor="pointer"
-                                                        onClick={() =>
-                                                            handleUnitChange(
-                                                                'chips'
-                                                            )
-                                                        }
-                                                        background="transparent"
-                                                        disabled={isDepositing}
-                                                    >
-                                                        <Text
-                                                            fontSize="xs"
-                                                            fontWeight="semibold"
-                                                            color={
-                                                                inputUnit ===
-                                                                'chips'
-                                                                    ? 'text.secondary'
-                                                                    : 'text.muted'
-                                                            }
-                                                            whiteSpace="nowrap"
-                                                        >
-                                                            Chips
-                                                        </Text>
-                                                    </Box>
-                                                    <Box
-                                                        as="button"
-                                                        type="button"
-                                                        flex="1"
-                                                        height="full"
-                                                        display="flex"
-                                                        alignItems="center"
-                                                        justifyContent="center"
-                                                        cursor="pointer"
-                                                        onClick={() =>
-                                                            handleUnitChange(
-                                                                'usdc'
-                                                            )
-                                                        }
-                                                        background="transparent"
-                                                        disabled={isDepositing}
-                                                    >
-                                                        <Text
-                                                            fontSize="xs"
-                                                            fontWeight="semibold"
-                                                            color={
-                                                                inputUnit ===
-                                                                'usdc'
-                                                                    ? 'text.secondary'
-                                                                    : 'text.muted'
-                                                            }
-                                                            whiteSpace="nowrap"
-                                                        >
-                                                            USDC
-                                                        </Text>
-                                                    </Box>
+                                                    {(['chips', 'usdc'] as const).map(
+                                                        (unit) => (
+                                                            <Box
+                                                                as="button"
+                                                                type="button"
+                                                                key={unit}
+                                                                flex="1"
+                                                                height="full"
+                                                                display="flex"
+                                                                alignItems="center"
+                                                                justifyContent="center"
+                                                                cursor="pointer"
+                                                                onClick={() =>
+                                                                    handleUnitChange(unit)
+                                                                }
+                                                                background="transparent"
+                                                                disabled={isDepositing}
+                                                            >
+                                                                <Text
+                                                                    fontSize="2xs"
+                                                                    fontWeight="bold"
+                                                                    letterSpacing="0.05em"
+                                                                    textTransform="uppercase"
+                                                                    color={
+                                                                        inputUnit === unit
+                                                                            ? 'text.secondary'
+                                                                            : 'text.muted'
+                                                                    }
+                                                                >
+                                                                    {unit === 'usdc'
+                                                                        ? 'USDC'
+                                                                        : 'Chips'}
+                                                                </Text>
+                                                            </Box>
+                                                        )
+                                                    )}
                                                 </Flex>
                                             </Box>
                                         )}
                                     </Flex>
-                                    <Box position="relative">
+                                    {/* Hero input — borderless, oversized, centered */}
+                                    <Flex
+                                        align="baseline"
+                                        justify="center"
+                                        gap={2}
+                                        opacity={isBalanceInsufficient ? 0.5 : 1}
+                                        transition="opacity 0.2s ease"
+                                    >
                                         <Input
                                             placeholder={
                                                 isCryptoGame
                                                     ? inputUnit === 'usdc'
-                                                        ? 'Enter USDC'
-                                                        : 'Enter chips'
-                                                    : 'Buy-in amount'
+                                                        ? '0.00'
+                                                        : '0'
+                                                    : '0'
                                             }
-                                            type="number"
-                                            step={
-                                                isCryptoGame &&
-                                                inputUnit === 'usdc'
-                                                    ? '0.01'
-                                                    : '1'
-                                            }
+                                            type="text"
                                             inputMode={
-                                                isCryptoGame &&
-                                                inputUnit === 'usdc'
+                                                isCryptoGame && inputUnit === 'usdc'
                                                     ? 'decimal'
                                                     : 'numeric'
                                             }
+                                            pattern={
+                                                isCryptoGame && inputUnit === 'usdc'
+                                                    ? '[0-9]*\\.?[0-9]*'
+                                                    : '[0-9]*'
+                                            }
+                                            autoComplete="off"
                                             onChange={(e) =>
-                                                handleBuyInChange(
-                                                    e.target.value
-                                                )
+                                                handleBuyInChange(e.target.value)
                                             }
                                             data-testid="buy-in-input"
-                                            variant={'takeSeatModal'}
-                                            required
-                                            isDisabled={isDepositing}
                                             value={buyInInput}
-                                            pr="70px"
+                                            isDisabled={isDepositing}
+                                            required
+                                            htmlSize={Math.max(
+                                                buyInInput.length || 4,
+                                                isCryptoGame && inputUnit === 'usdc'
+                                                    ? 4
+                                                    : 1
+                                            )}
+                                            variant="unstyled"
+                                            textAlign="right"
+                                            fontSize="4xl"
+                                            fontWeight="bold"
+                                            letterSpacing="-0.03em"
+                                            color="text.secondary"
+                                            lineHeight={1}
+                                            height="auto"
+                                            width="auto"
+                                            minW={0}
+                                            flex="0 0 auto"
                                         />
                                         <Text
-                                            position="absolute"
-                                            right="16px"
-                                            top="50%"
-                                            transform="translateY(-50%)"
-                                            fontSize="xs"
+                                            fontSize="md"
+                                            fontWeight="bold"
                                             color="text.muted"
-                                            fontWeight="semibold"
-                                            letterSpacing="0.02em"
-                                            pointerEvents="none"
                                             textTransform="uppercase"
+                                            letterSpacing="0.06em"
                                         >
-                                            {isCryptoGame
-                                                ? inputUnit
-                                                : 'chips'}
+                                            {isCryptoGame ? inputUnit : 'chips'}
                                         </Text>
-                                    </Box>
-                                    {isCryptoGame && (
-                                        <Flex
-                                            mt={2}
-                                            alignItems="center"
-                                            justifyContent="space-between"
-                                            gap={2}
-                                            fontSize="xs"
-                                            color="text.secondary"
-                                            fontWeight="medium"
-                                            lineHeight="short"
+                                    </Flex>
+                                    {/* Conversion line: show only the *other* unit */}
+                                    {isCryptoGame && formattedChipsEstimate && (
+                                        <Text
+                                            mt={1.5}
+                                            textAlign="right"
+                                            fontSize="2xs"
+                                            color="text.muted"
+                                            fontWeight="bold"
+                                            textTransform="uppercase"
+                                            letterSpacing="0.06em"
                                         >
-                                            <Flex
-                                                alignItems="center"
-                                                gap={1}
-                                                minWidth={0}
-                                            >
-                                                {inputUnit === 'chips' ? (
-                                                    <>
-                                                        <Text
-                                                            as="span"
-                                                            color="text.secondary"
-                                                            isTruncated
-                                                        >
-                                                            {CHIPS_PER_USDC}{' '}
-                                                            chips = 1
-                                                        </Text>
-                                                        <Text
-                                                            as="span"
-                                                            color="text.secondary"
-                                                            isTruncated
-                                                        >
-                                                            USDC
-                                                        </Text>
-                                                        <Image
-                                                            src={USDC_LOGO_URL}
-                                                            alt="USDC"
-                                                            boxSize="14px"
-                                                            loading="lazy"
-                                                            flexShrink={0}
-                                                        />
-                                                    </>
-                                                ) : (
-                                                    <>
-                                                        <Text
-                                                            as="span"
-                                                            color="text.secondary"
-                                                            isTruncated
-                                                        >
-                                                            1 USDC
-                                                        </Text>
-                                                        <Image
-                                                            src={USDC_LOGO_URL}
-                                                            alt="USDC"
-                                                            boxSize="14px"
-                                                            loading="lazy"
-                                                            flexShrink={0}
-                                                        />
-                                                        <Text
-                                                            as="span"
-                                                            color="text.secondary"
-                                                            isTruncated
-                                                        >
-                                                            = {CHIPS_PER_USDC}{' '}
-                                                            chips
-                                                        </Text>
-                                                    </>
-                                                )}
-                                            </Flex>
-                                            {formattedChipsEstimate &&
-                                                formattedUsdcEstimate && (
-                                                    <Text
-                                                        as="span"
-                                                        color="text.secondary"
-                                                        textAlign="right"
-                                                        whiteSpace="nowrap"
-                                                    >
-                                                        {inputUnit === 'chips'
-                                                            ? `~ ${formattedUsdcEstimate} USDC`
-                                                            : `~ ${formattedChipsEstimate} chips`}
-                                                    </Text>
-                                                )}
-                                        </Flex>
+                                            ≈{' '}
+                                            {inputUnit === 'usdc'
+                                                ? `${formattedChipsEstimate} chips`
+                                                : `$${formattedUsdcEstimate}`}
+                                        </Text>
                                     )}
-                                </FormControl>}
+                                </FormControl>
 
+                                {/* Preset pills */}
+                                {bb > 0 && (
+                                    <BuyInPresets
+                                        bb={bb}
+                                        maxBuyIn={maxBuyIn}
+                                        walletBalanceChips={walletBalanceChips}
+                                        isCrypto={isCryptoGame}
+                                        selectedChips={buyIn}
+                                        onSelect={applyBuyInChips}
+                                        disabled={isDepositing}
+                                    />
+                                )}
                             </VStack>
-                        </Center>
-                    </ModalBody>
+                        </ModalBody>
 
-                    <ModalFooter px={7} pb={7} pt={2}>
-                        <VStack w="100%" spacing={4}>
-                            {/* Wallet Button */}
-                            <WalletButton width="100%" height="56px" />
+                        <ModalFooter px={{ base: 5, sm: 7 }} pb={6} pt={3}>
+                            <VStack w="100%" spacing={3}>
+                                <WalletButton width="100%" height="52px" />
 
-                            {/* Withdraw-first footer: show instead of normal join flow */}
-                            {showWithdrawFirst && (
-                                <>
-                                    {withdrawStatus === 'error' && withdrawError && (
-                                        <HStack
-                                            spacing={2}
-                                            alignItems="flex-start"
-                                            bg="red.50"
-                                            color="red.700"
-                                            borderRadius="md"
-                                            px={3}
-                                            py={2}
+                                {needsWalletSignIn && (
+                                    <HStack
+                                        spacing={2}
+                                        alignItems="flex-start"
+                                        bg="rgba(54, 163, 123, 0.15)"
+                                        borderRadius="md"
+                                        px={3}
+                                        py={2}
+                                        width="100%"
+                                    >
+                                        <Icon
+                                            as={FaInfoCircle}
+                                            boxSize={3.5}
+                                            mt={0.5}
+                                            color="brand.green"
+                                        />
+                                        <Text
                                             fontSize="xs"
-                                            fontWeight="medium"
-                                            width="100%"
-                                            alignSelf="stretch"
+                                            fontWeight="semibold"
+                                            color="brand.green"
+                                            textAlign="left"
                                         >
-                                            <Icon
-                                                as={FaInfoCircle}
-                                                boxSize={3.5}
-                                                mt={0.5}
-                                            />
-                                            <Text
-                                                color="inherit"
-                                                textAlign="left"
-                                                wordBreak="break-word"
-                                            >
-                                                {withdrawError}
-                                            </Text>
-                                        </HStack>
-                                    )}
+                                            {cryptoJoinHint}
+                                        </Text>
+                                    </HStack>
+                                )}
+                                {isBalanceInsufficient && (
+                                    <HStack
+                                        spacing={2}
+                                        alignItems="flex-start"
+                                        bg="red.50"
+                                        borderRadius="md"
+                                        px={3}
+                                        py={2}
+                                        width="100%"
+                                    >
+                                        <Icon
+                                            as={FaInfoCircle}
+                                            boxSize={3.5}
+                                            mt={0.5}
+                                            color="red.700"
+                                        />
+                                        <Text
+                                            fontSize="xs"
+                                            fontWeight="semibold"
+                                            color="red.700"
+                                            textAlign="left"
+                                        >
+                                            Insufficient USDC balance
+                                            {formattedUsdcBalance
+                                                ? ` (you have ${formattedUsdcBalance} USDC)`
+                                                : ''}
+                                            .
+                                        </Text>
+                                    </HStack>
+                                )}
+                                {depositStatus === 'error' && depositError && (
+                                    <HStack
+                                        spacing={2}
+                                        alignItems="flex-start"
+                                        bg="red.50"
+                                        borderRadius="md"
+                                        px={3}
+                                        py={2}
+                                        width="100%"
+                                    >
+                                        <Icon
+                                            as={FaInfoCircle}
+                                            boxSize={3.5}
+                                            mt={0.5}
+                                            color="red.700"
+                                        />
+                                        <Text
+                                            fontSize="xs"
+                                            fontWeight="semibold"
+                                            color="red.700"
+                                            textAlign="left"
+                                            wordBreak="break-word"
+                                        >
+                                            {depositError}
+                                        </Text>
+                                    </HStack>
+                                )}
+
+                                {/* Dual-unit CTA */}
+                                <Tooltip
+                                    label={cryptoJoinHint}
+                                    isDisabled={!needsWalletSignIn}
+                                    placement="top"
+                                    fontSize="xs"
+                                    bg="brand.navy"
+                                    color="white"
+                                    borderRadius="md"
+                                    px={2}
+                                    py={1}
+                                >
                                     <Button
                                         w="100%"
-                                        h="50px"
-                                        fontSize="md"
-                                        fontWeight="bold"
-                                        borderRadius={'bigButton'}
-                                        bg="brand.pink"
-                                        color="white"
+                                        h="56px"
+                                        borderRadius="bigButton"
+                                        bg={
+                                            isJoinVisuallyDisabled
+                                                ? 'btn.lightGray'
+                                                : 'brand.green'
+                                        }
                                         border="none"
-                                        isLoading={isWithdrawing}
-                                        loadingText="Withdrawing chips..."
-                                        _hover={{
-                                            bg: 'brand.pink',
-                                            transform: 'translateY(-2px)',
-                                            boxShadow:
-                                                '0 12px 24px rgba(255, 105, 135, 0.35)',
+                                        cursor={
+                                            isJoinVisuallyDisabled
+                                                ? 'not-allowed'
+                                                : 'pointer'
+                                        }
+                                        aria-disabled={
+                                            isJoinVisuallyDisabled || undefined
+                                        }
+                                        isDisabled={isJoinDisabled}
+                                        isLoading={isDepositing}
+                                        loadingText={
+                                            getDepositStatusMessage() ||
+                                            'Processing...'
+                                        }
+                                        boxShadow={
+                                            isJoinVisuallyDisabled
+                                                ? 'none'
+                                                : '0 6px 18px rgba(54, 163, 123, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.15)'
+                                        }
+                                        _disabled={{
+                                            bg: 'btn.lightGray',
+                                            cursor: 'not-allowed',
+                                            opacity: 0.7,
+                                            boxShadow: 'none',
+                                        }}
+                                        _hover={
+                                            isJoinVisuallyDisabled
+                                                ? {}
+                                                : {
+                                                      bg: '#2E8A66',
+                                                      transform: 'translateY(-2px)',
+                                                      boxShadow:
+                                                          '0 14px 28px rgba(54, 163, 123, 0.42), inset 0 1px 0 rgba(255, 255, 255, 0.22)',
+                                                  }
+                                        }
+                                        _active={{
+                                            bg: isJoinVisuallyDisabled
+                                                ? 'btn.lightGray'
+                                                : '#287859',
+                                            transform: isJoinVisuallyDisabled
+                                                ? 'none'
+                                                : 'translateY(0) scale(0.99)',
+                                            boxShadow: isJoinVisuallyDisabled
+                                                ? 'none'
+                                                : '0 4px 12px rgba(54, 163, 123, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.15)',
                                         }}
                                         transition="all 0.2s ease"
-                                        onClick={handleWithdraw}
+                                        onClick={handleJoin}
+                                        type="submit"
+                                        data-testid="join-table-btn"
                                     >
-                                        Withdraw chips &amp; start fresh
+                                        <Text
+                                            fontSize="md"
+                                            fontWeight="bold"
+                                            letterSpacing="-0.01em"
+                                            color={
+                                                isJoinVisuallyDisabled
+                                                    ? 'text.muted'
+                                                    : 'white'
+                                            }
+                                        >
+                                            {isCryptoGame
+                                                ? formattedUsdcEstimate
+                                                    ? `Sit down · $${formattedUsdcEstimate}`
+                                                    : 'Sit down'
+                                                : 'Join game'}
+                                        </Text>
                                     </Button>
-                                </>
-                            )}
+                                </Tooltip>
 
-                            {!showWithdrawFirst && needsWalletSignIn && (
-                                <HStack
-                                    spacing={2}
-                                    alignItems="flex-start"
-                                    bg="rgba(54, 163, 123, 0.12)"
-                                    color="green.700"
-                                    borderRadius="md"
-                                    px={3}
-                                    py={2}
-                                    fontSize="xs"
-                                    fontWeight="medium"
-                                    width="100%"
-                                    alignSelf="stretch"
-                                >
-                                    <Icon
-                                        as={FaInfoCircle}
-                                        boxSize={3.5}
-                                        mt={0.5}
-                                    />
-                                    <Text color="inherit" textAlign="left">
-                                        {cryptoJoinHint}
-                                    </Text>
-                                </HStack>
-                            )}
-                            {!showWithdrawFirst && isBalanceInsufficient && (
-                                <HStack
-                                    spacing={2}
-                                    alignItems="flex-start"
-                                    bg="red.50"
-                                    color="red.700"
-                                    borderRadius="md"
-                                    px={3}
-                                    py={2}
-                                    fontSize="xs"
-                                    fontWeight="medium"
-                                    width="100%"
-                                    alignSelf="stretch"
-                                >
-                                    <Icon
-                                        as={FaInfoCircle}
-                                        boxSize={3.5}
-                                        mt={0.5}
-                                    />
-                                    <Text color="inherit" textAlign="left">
-                                        Insufficient USDC balance
-                                        {formattedUsdcBalance
-                                            ? ` (balance: ${formattedUsdcBalance} USDC)`
-                                            : ''}
-                                        .
-                                    </Text>
-                                </HStack>
-                            )}
-                            {/* Deposit Error Message */}
-                            {!showWithdrawFirst && depositStatus === 'error' && depositError && (
-                                <HStack
-                                    spacing={2}
-                                    alignItems="flex-start"
-                                    bg="red.50"
-                                    color="red.700"
-                                    borderRadius="md"
-                                    px={3}
-                                    py={2}
-                                    fontSize="xs"
-                                    fontWeight="medium"
-                                    width="100%"
-                                    alignSelf="stretch"
-                                >
-                                    <Icon
-                                        as={FaInfoCircle}
-                                        boxSize={3.5}
-                                        mt={0.5}
-                                    />
-                                    <Text
-                                        color="inherit"
-                                        textAlign="left"
-                                        wordBreak="break-word"
-                                    >
-                                        {depositError}
-                                    </Text>
-                                </HStack>
-                            )}
-
-                            {/* Join Button */}
-                            {!showWithdrawFirst && <Tooltip
-                                label={cryptoJoinHint}
-                                isDisabled={!needsWalletSignIn}
-                                placement="top"
-                                fontSize="xs"
-                                bg="brand.navy"
-                                color="white"
-                                borderRadius="md"
-                                px={2}
-                                py={1}
-                            >
-                                <Button
-                                    w="100%"
-                                    h="50px"
-                                    fontSize="md"
-                                    fontWeight="bold"
-                                    borderRadius={'bigButton'}
-                                    bg={
-                                        isJoinVisuallyDisabled
-                                            ? 'gray.300'
-                                            : 'brand.green'
-                                    }
-                                    color={
-                                        isJoinVisuallyDisabled
-                                            ? 'gray.500'
-                                            : 'white'
-                                    }
-                                    border="none"
-                                    cursor={
-                                        isJoinVisuallyDisabled
-                                            ? 'not-allowed'
-                                            : 'pointer'
-                                    }
-                                    aria-disabled={
-                                        isJoinVisuallyDisabled || undefined
-                                    }
-                                    isDisabled={isJoinDisabled}
-                                    isLoading={isDepositing}
-                                    loadingText={
-                                        getDepositStatusMessage() ||
-                                        'Processing...'
-                                    }
-                                    _disabled={{
-                                        bg: 'gray.300',
-                                        color: 'gray.500',
-                                        cursor: 'not-allowed',
-                                        opacity: 0.6,
-                                    }}
-                                    _active={{
-                                        transform: isJoinVisuallyDisabled
-                                            ? 'none'
-                                            : 'translateY(0)',
-                                    }}
-                                    position="relative"
-                                    overflow="hidden"
-                                    _before={{
-                                        content: '""',
-                                        position: 'absolute',
-                                        top: 0,
-                                        left: 0,
-                                        right: 0,
-                                        bottom: 0,
-                                        bg: 'linear-gradient(135deg, transparent, rgba(255,255,255,0.3), transparent)',
-                                        transform: 'translateX(-100%)',
-                                        transition: 'transform 0.6s',
-                                        opacity: isJoinVisuallyDisabled ? 0 : 1,
-                                    }}
-                                    _hover={
-                                        isJoinVisuallyDisabled
-                                            ? {}
-                                            : {
-                                                  bg: 'brand.green',
-                                                  transform: 'translateY(-2px)',
-                                                  boxShadow:
-                                                      '0 12px 24px rgba(54, 163, 123, 0.35)',
-                                                  _before: {
-                                                      transform:
-                                                          'translateX(100%)',
-                                                  },
-                                              }
-                                    }
-                                    transition="all 0.2s ease"
-                                    onClick={handleJoin}
-                                    type="submit"
-                                    data-testid="join-table-btn"
-                                >
-                                    {isCryptoGame
-                                        ? `Buy In${formattedUsdcEstimate ? ` ${formattedUsdcEstimate} USDC` : ''}`
-                                        : 'Join Game'}
-                                </Button>
-                            </Tooltip>}
-                            {!showWithdrawFirst && isCryptoGame && (
-                                <Text
-                                    fontSize="2xs"
-                                    color="text.muted"
-                                    textAlign="center"
-                                    lineHeight="short"
-                                    px={2}
-                                    opacity={0.7}
-                                >
-                                    Your USDC is deposited into the table
-                                    contract and converted to chips. Chip
-                                    balances update after each settled hand.
-                                    {' '}{CHIPS_PER_USDC}
-                                    {' '}chips&nbsp;=&nbsp;1&nbsp;USDC.
-                                    {contractAddress && (
-                                        <>
-                                            {' '}
-                                            <Link
-                                                href={`https://sepolia.basescan.org/address/${contractAddress}`}
-                                                isExternal
-                                                color="brand.navy"
-                                                _dark={{
-                                                    color: 'brand.lightGray',
-                                                }}
-                                                fontWeight="semibold"
-                                                textDecoration="underline"
-                                                textUnderlineOffset="2px"
+                                {/* Collapsible fine print */}
+                                {isCryptoGame && (
+                                    <Box w="100%" pt={1}>
+                                        <Box
+                                            as="button"
+                                            type="button"
+                                            onClick={finePrintDisclosure.onToggle}
+                                            w="100%"
+                                            display="flex"
+                                            alignItems="center"
+                                            justifyContent="center"
+                                            gap={1.5}
+                                            py={1}
+                                            cursor="pointer"
+                                            bg="transparent"
+                                            border="none"
+                                            opacity={0.85}
+                                            _hover={{ opacity: 1 }}
+                                            transition="opacity 0.15s ease"
+                                        >
+                                            <Text
+                                                fontSize="xs"
+                                                color="text.secondary"
+                                                fontWeight="bold"
                                             >
-                                                View contract
-                                            </Link>
-                                        </>
-                                    )}
-                                </Text>
-                            )}
-                        </VStack>
-                    </ModalFooter>
-                </Box>
-
-                {/* Decorative Background Elements */}
-                <Box
-                    position="absolute"
-                    top="-20px"
-                    right="-20px"
-                    width="120px"
-                    height="120px"
-                    borderRadius="50%"
-                    bg="brand.pink"
-                    opacity={0.08}
-                    filter="blur(40px)"
-                    pointerEvents="none"
-                />
-                <Box
-                    position="absolute"
-                    bottom="-30px"
-                    left="-30px"
-                    width="140px"
-                    height="140px"
-                    borderRadius="50%"
-                    bg="brand.green"
-                    opacity={0.08}
-                    filter="blur(50px)"
-                    pointerEvents="none"
-                />
+                                                How does this work?
+                                            </Text>
+                                            <Icon
+                                                as={FaChevronDown}
+                                                boxSize={2.5}
+                                                color="text.secondary"
+                                                transform={
+                                                    finePrintDisclosure.isOpen
+                                                        ? 'rotate(180deg)'
+                                                        : 'rotate(0deg)'
+                                                }
+                                                transition="transform 0.2s ease"
+                                            />
+                                        </Box>
+                                        <Collapse
+                                            in={finePrintDisclosure.isOpen}
+                                            animateOpacity
+                                        >
+                                            <Text
+                                                fontSize="2xs"
+                                                color="text.muted"
+                                                textAlign="center"
+                                                lineHeight="short"
+                                                px={2}
+                                                pt={2}
+                                                opacity={0.75}
+                                            >
+                                                Your USDC is deposited into the table
+                                                contract and converted to chips. Chip
+                                                balances update after each settled hand.
+                                                {' '}{CHIPS_PER_USDC}
+                                                {' '}chips&nbsp;=&nbsp;1&nbsp;USDC.
+                                                {contractAddress && (
+                                                    <>
+                                                        {' '}
+                                                        <Link
+                                                            href={`https://sepolia.basescan.org/address/${contractAddress}`}
+                                                            isExternal
+                                                            color="brand.navy"
+                                                            _dark={{
+                                                                color: 'brand.lightGray',
+                                                            }}
+                                                            fontWeight="semibold"
+                                                            textDecoration="underline"
+                                                            textUnderlineOffset="2px"
+                                                        >
+                                                            View contract
+                                                        </Link>
+                                                    </>
+                                                )}
+                                            </Text>
+                                        </Collapse>
+                                    </Box>
+                                )}
+                            </VStack>
+                        </ModalFooter>
+                    </>
+                )}
             </ModalContent>
         </Modal>
     );

--- a/app/lib/takeSeat/chipBreakdown.ts
+++ b/app/lib/takeSeat/chipBreakdown.ts
@@ -1,0 +1,70 @@
+export interface ChipColumn {
+    /** semantic color token for the chip face */
+    color: 'white' | 'red' | 'green' | 'black' | 'purple';
+    /** stroke color token */
+    stripe: string;
+    /** value per chip, in chips */
+    denom: number;
+    /** how many chips to render in the visible stack (cap applied) */
+    visible: number;
+    /** raw count including overflow */
+    count: number;
+}
+
+const MAX_STACK_HEIGHT = 8;
+
+const CHIP_STYLES: Array<Pick<ChipColumn, 'color' | 'stripe'>> = [
+    { color: 'white', stripe: 'brand.navy' },
+    { color: 'red', stripe: 'white' },
+    { color: 'green', stripe: 'white' },
+    { color: 'black', stripe: 'brand.yellow' },
+    { color: 'purple', stripe: 'white' },
+];
+
+/**
+ * Breaks a chip amount into up to 4 denomination columns scaled to the
+ * table's big blind, for the ChipStackVisualizer. Denominations scale with
+ * bb so the same visual works at $0.10/$0.20 and $100/$200.
+ */
+export function breakdownChips(chips: number, bb: number): ChipColumn[] {
+    if (!Number.isFinite(chips) || chips <= 0 || bb <= 0) return [];
+
+    const denoms = [
+        Math.max(1, Math.round(bb * 25)),
+        Math.max(1, Math.round(bb * 5)),
+        Math.max(1, Math.round(bb)),
+        Math.max(1, Math.round(bb / 4)),
+    ];
+
+    let remaining = chips;
+    const columns: ChipColumn[] = [];
+
+    denoms.forEach((denom, idx) => {
+        if (remaining < denom) return;
+        const count = Math.floor(remaining / denom);
+        remaining -= count * denom;
+        columns.push({
+            ...CHIP_STYLES[idx],
+            denom,
+            count,
+            visible: Math.min(count, MAX_STACK_HEIGHT),
+        });
+    });
+
+    // If the highest denom filled everything, make sure there's still visual
+    // variety by nudging one chip down to the next tier.
+    if (columns.length === 1 && columns[0].count > 1) {
+        const [single] = columns;
+        return [
+            { ...single, count: single.count - 1, visible: Math.min(single.count - 1, MAX_STACK_HEIGHT) },
+            {
+                ...CHIP_STYLES[1],
+                denom: Math.max(1, Math.round(single.denom / 5)),
+                count: 1,
+                visible: 1,
+            },
+        ];
+    }
+
+    return columns;
+}

--- a/app/lib/takeSeat/lastBuyIn.ts
+++ b/app/lib/takeSeat/lastBuyIn.ts
@@ -1,0 +1,28 @@
+const STORAGE_PREFIX = 'takeSeat:lastBuyIn:';
+
+const keyFor = (tableId: string): string => `${STORAGE_PREFIX}${tableId}`;
+
+export function readLastBuyIn(tableId: string | null | undefined): number | null {
+    if (!tableId || typeof window === 'undefined') return null;
+    try {
+        const raw = window.localStorage.getItem(keyFor(tableId));
+        if (!raw) return null;
+        const parsed = Number(raw);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+export function writeLastBuyIn(
+    tableId: string | null | undefined,
+    chips: number
+): void {
+    if (!tableId || typeof window === 'undefined') return;
+    if (!Number.isFinite(chips) || chips <= 0) return;
+    try {
+        window.localStorage.setItem(keyFor(tableId), String(Math.round(chips)));
+    } catch {
+        // ignore storage failures (quota, private mode)
+    }
+}

--- a/app/lib/takeSeat/presets.ts
+++ b/app/lib/takeSeat/presets.ts
@@ -1,0 +1,143 @@
+const CHIPS_PER_USDC = 100;
+
+const NICE_USDC = [
+    1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000,
+    100000,
+];
+
+const TARGET_BB = [50, 100, 150];
+const FALLBACK_BB = [50, 100, 200];
+
+export interface PresetInput {
+    bb: number;
+    maxBuyIn: number;
+    walletBalanceChips: number | null;
+    isCrypto: boolean;
+}
+
+export interface BuyInPreset {
+    key: string;
+    label: string;
+    sublabel: string;
+    chips: number;
+    disabled: boolean;
+    isMax: boolean;
+}
+
+const snapNearest = (value: number, ladder: number[]): number => {
+    return ladder.reduce((prev, curr) =>
+        Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev
+    );
+};
+
+const formatUsdc = (dollars: number): string => {
+    if (dollars >= 1000) {
+        return '$' + Math.round(dollars).toLocaleString('en-US');
+    }
+    if (dollars >= 10) return '$' + dollars.toFixed(0);
+    return '$' + dollars.toFixed(2);
+};
+
+const formatChipsPlain = (chips: number): string =>
+    chips.toLocaleString('en-US');
+
+const formatBB = (bbCount: number): string => {
+    if (bbCount >= 100) return `${Math.round(bbCount)} BB`;
+    return `${Math.round(bbCount * 10) / 10} BB`;
+};
+
+const buildBBPreset = (
+    mult: number,
+    bb: number,
+    maxBuyIn: number,
+    isCrypto: boolean,
+    walletBalanceChips: number | null
+): BuyInPreset => {
+    let chips: number;
+    let label: string;
+    let sublabel: string;
+
+    if (isCrypto) {
+        const targetUsdc = (mult * bb) / CHIPS_PER_USDC;
+        const snappedUsdc = snapNearest(targetUsdc, NICE_USDC);
+        chips = Math.round(snappedUsdc * CHIPS_PER_USDC);
+        label = formatUsdc(snappedUsdc);
+        sublabel = formatBB(chips / bb);
+    } else {
+        chips = mult * bb;
+        label = formatChipsPlain(chips);
+        sublabel = `${mult} BB`;
+    }
+
+    const cappedByMax = maxBuyIn > 0 ? Math.min(chips, maxBuyIn) : chips;
+    const disabled =
+        walletBalanceChips !== null && cappedByMax > walletBalanceChips;
+
+    return {
+        key: `bb-${mult}`,
+        label,
+        sublabel,
+        chips: cappedByMax,
+        disabled,
+        isMax: false,
+    };
+};
+
+const buildMaxPreset = (
+    maxBuyIn: number,
+    walletBalanceChips: number | null,
+    bb: number,
+    isCrypto: boolean
+): BuyInPreset => {
+    const cap =
+        walletBalanceChips !== null
+            ? Math.min(maxBuyIn, walletBalanceChips)
+            : maxBuyIn;
+    const chips = Math.max(cap, 0);
+
+    const label = 'Max';
+    let sublabel = '';
+    if (chips > 0) {
+        if (bb > 0) {
+            sublabel = formatBB(chips / bb);
+        } else if (isCrypto) {
+            sublabel = formatUsdc(chips / CHIPS_PER_USDC);
+        } else {
+            sublabel = formatChipsPlain(chips);
+        }
+    }
+
+    return {
+        key: 'max',
+        label,
+        sublabel,
+        chips,
+        disabled: chips <= 0,
+        isMax: true,
+    };
+};
+
+/**
+ * Builds up to 4 buy-in preset pills.
+ * BB-anchored targets (50/100/150) snapped to nice USDC numbers for crypto
+ * tables, raw chip values for free games. Duplicates collapse to the fallback
+ * ladder (50/100/200) so the row always renders 3 distinct pills + Max.
+ */
+export function buildBuyInPresets(input: PresetInput): BuyInPreset[] {
+    const { bb, maxBuyIn, walletBalanceChips, isCrypto } = input;
+    if (!bb || bb <= 0) return [];
+
+    const build = (mults: number[]): BuyInPreset[] =>
+        mults.map((m) =>
+            buildBBPreset(m, bb, maxBuyIn, isCrypto, walletBalanceChips)
+        );
+
+    let pills = build(TARGET_BB);
+    const uniqueChips = new Set(pills.map((p) => p.chips));
+    if (uniqueChips.size < TARGET_BB.length) {
+        pills = build(FALLBACK_BB);
+    }
+
+    pills.push(buildMaxPreset(maxBuyIn, walletBalanceChips, bb, isCrypto));
+    return pills;
+}


### PR DESCRIPTION
…rast

- Replace chip stack visualizer with oversized centered buy-in input (number + unit as a centered cluster; htmlSize tracks content width)
- Preset pills show BB depth as sublabel on crypto tables ($10 / 50 BB) instead of chip count; Max preset also shows BB when blinds are known
- Switch input to type="text" + inputMode="decimal"/"numeric" for reliable numeric keypad on iOS/Android
- Add BUY-IN label left-aligned in all game modes
- Explicit color on every <Text> and <Icon> — no reliance on CSS inheritance which Chakra Text baseStyle overrides
- Sit Down CTA: darker hover (#2E8A66), active (#287859), green glow shadow; disabled uses btn.lightGray with text.muted text
- Alert banners: explicit color on Text/Icon children (red.700 / brand.green)
- "How does this work?" wrapped in <Text> with text.secondary color
- Conversion ≈ line right-aligned and uppercase
- All 9 Storybook stories mirrored with same changes